### PR TITLE
Initial GeoGit implementation.

### DIFF
--- a/mapstory/settings/__init__.py
+++ b/mapstory/settings/__init__.py
@@ -67,7 +67,7 @@ DATABASES = {
 INSTALLED_APPS += (
     'mapstory',
     'django.contrib.webdesign',
-    'geonode.contrib.geogig',
+    'geonode.contrib.geogit',
     'icon_commons'
 )
 
@@ -94,7 +94,8 @@ OGC_SERVER = {
         'WPS_ENABLED' : True,
         # Set to name of database in DATABASES dictionary to enable
         'DATASTORE': '', #'datastore',
-        'TIMEOUT': 10  # number of seconds to allow for HTTP requests
+        'TIMEOUT': 10,  # number of seconds to allow for HTTP requests,
+        'GEOGIT_DATASTORE_DIR': '/var/lib/geoserver/data/geogit'
     }
 }
 

--- a/mapstory/templates/maps/mapstory_map_view.html
+++ b/mapstory/templates/maps/mapstory_map_view.html
@@ -12,8 +12,8 @@
 config =  {
      authStatus: {% if user.is_authenticated %} 200{% else %} 401{% endif %},
       username: {% if user.is_authenticated %} "{{ user.username }}" {% else %} undefined {% endif %},
-      userprofilename: {% if user.is_authenticated %} "{{ user.profile.name }}" {% else %} undefined {% endif %},
-      userprofileemail: {% if user.is_authenticated %} "{{ user.profile.email }}" {% else %} undefined {% endif %},
+      userprofilename: {% if user.is_authenticated %} "{{ user.get_full_name }}" {% else %} undefined {% endif %},
+      userprofileemail: {% if user.is_authenticated %} "{{ user.email }}" {% else %} undefined {% endif %},
       currentLanguage: "{{language|default:'en'}}",
       proxy: '{{ PROXY_URL }}',
       {% if MF_PRINT_ENABLED %}

--- a/scripts/provision/admin.yml
+++ b/scripts/provision/admin.yml
@@ -86,6 +86,10 @@
   file: path=/srv/git state=directory owner=mapstory group=www-data
   tags: [config, files]
 
+- name: create www-data home directory
+  file: path=/var/www state=directory mode=0775 owner=www-data group=www-data recurse=true
+  tags: [setup]
+
 - name: gunicorn-app
   copy: src=files/gunicorn-app.sh dest=/srv/scripts/gunicorn-app.sh mode=650 owner=mapstory group=www-data
   notify: [restart django]
@@ -144,6 +148,10 @@
   file: path=/var/lib/geoserver/data state=directory owner=www-data group=www-data mode=775 recurse=yes
   tags: [geoserver]
 
+- name: create geogit data directory
+  file: path=/var/lib/geoserver/data/geogit state=directory mode=0775 owner=www-data group=www-data
+  tags: [setup]
+
 - name: jetty app permissions
   file: path={{mapstory_geonode}}/scripts/misc/jetty-runner mode=650 owner=mapstory group=www-data
   tags: [geoserver]
@@ -152,3 +160,7 @@
   template: src=files/supervisor-jetty.conf dest=/etc/supervisor/conf.d
   notify: [reload supervisor, restart geoserver]
   tags: [config, geoserver]
+
+- name: geogig global config
+  copy: src=files/geogigconfig dest=/var/www/.geogitconfig
+  tags: [setup]

--- a/scripts/provision/mapstory.yml
+++ b/scripts/provision/mapstory.yml
@@ -45,10 +45,6 @@
   file: path={{ media_root }} owner=www-data group=www-data mode=0775 state=directory
   tags: [setup, media]
 
-- name: geogig global config
-  copy: src=files/geogigconfig dest=~/.geogigconfig
-  tags: [setup]
-
 - name: compile python
   shell: '{{ venv }}/bin/python -m compileall -f {{ top_project }}/geonode -f {{ mapstory_geonode }}'
   notify: restart django


### PR DESCRIPTION
- This will not work unless https://github.com/MapStory/geonode/pull/1 is merged and deployed.

Deployment notes:
- Make sure www-data's home directory exists (`/var/www/`) and is readable/writable by `www-data:www-data`.
- Make a geogit directory in the geoserver data directory: `/var/lib/geoserver/data/geogit state=directory mode=0775 owner=www-data group=www-data`
- Create `/var/www/.geogitconfig` with this as the contents: https://github.com/MapStory/mapstory-geonode/blob/master/scripts/provision/files/geogigconfig.
- Use supervisor to restart `gunicorn-django` and `geoserver`.
