### PR TITLE
Added home page search and quick search

### DIFF
--- a/mapstory/templates/index.html
+++ b/mapstory/templates/index.html
@@ -12,10 +12,32 @@
 {% endblock %}
 
 {% block extra_script %}
+{{ block.super }}
 <script type="text/javascript" src="{{ STATIC_URL }}vendor/modernizr/modernizr.js"></script>
 <script type="text/javascript" src="{{ STATIC_URL }}vendor/jquery.stellar/jquery.stellar.min.js"></script>
 <script type="text/javascript" src="{{ STATIC_URL }}vendor/isotope/jquery.isotope.min.js"></script>
 <script type="text/javascript" src="{{ STATIC_URL }}mapstory/js/index.js"></script>
+<script type="text/javascript">
+    /* Script for keywords autocomplete */
+    var homepage_autocomplete = $('#homepage_search').yourlabsAutocomplete({
+          url: '{% url "autocomplete_light_autocomplete" "TagAutocomplete" %}',
+          choiceSelector: 'span',
+          hideAfter: 200,
+          minimumCharacters: 1,
+          appendAutocomplete: $('#homepage_search'),
+          placeholder: gettext('Enter keyword here ...')
+    });
+    $('#homepage_search').bind('selectChoice', function(e, choice, homepage_autocomplete) {
+          if(choice[0].children[0] == undefined) {
+              $('#homepage_search').val(choice[0].innerHTML);
+              $scope.keyword_query = choice[0].innerHTML;
+          }
+    });
+    // Fix placeholder text for Home Page Search
+    $(function() {
+        $('#homepage_search').attr('placeholder','Explore MapStories and StoryLayers');
+    });
+</script>
 {% endblock %}
 
 {% block middle %}
@@ -33,9 +55,16 @@
             </div>
             <div class="row" style="padding-top: 5px;">
                 <div class="input-group col-sm-6 col-sm-offset-3">
-                    <!-- TODO: Need to make this functional -->
-                    <input class="form-control " id="appendedInput" type="text" placeholder="Explore MapStories and StoryLayers" style="color:chocolate;background-color:whitesmoke;border:1px solid white">
-                    <span class="input-group-addon" style="background-color:chocolate;color:white;border:1px solid white"><i class="fa fa-search"></i></span>
+                    <form action="{% url "search" %}">
+                        {% if HAYSTACK_SEARCH %}
+                        <input class="form-control" id="homepage_search" type="text" name="q" style="color:chocolate;background-color:whitesmoke;border:1px solid white">
+                        {% else %}
+                        <input class="form-control" id="homepage_search" type="text" name="keywords__slug__in" style="color:chocolate;background-color:whitesmoke;border:1px solid white">
+                        {% endif %}
+                        <span class="input-group-btn">
+                          <button class="btn btn-primary" type="submit" style="background-color:chocolate;color:white;border:1px solid white"><i class="fa fa-search"></i></button>
+                        </span>
+                    </form>
                </div>
             </div>
             <div class="row links" style="padding-top:15px;padding-bottom:5px;">

--- a/mapstory/templates/mapstory/_header.html
+++ b/mapstory/templates/mapstory/_header.html
@@ -24,6 +24,20 @@
                     <a href="{% url "diary" %}">{% trans "Journal" %}</a>
                 </li>
             </ul>
+            <form class="nav navbar-nav navbar-form" id="search" action="{% url "search" %}" >
+                <div class="col-md-3" style="width:100%;">
+                  <div class="input-group">
+                    {% if HAYSTACK_SEARCH %}
+                    <input id="quicksearch" type="text" class="form-control" name="q">
+                    {% else %}
+                    <input id="quicksearch" type="text" class="form-control" name="keywords__slug__in">
+                    {% endif %}
+                    <span class="input-group-btn">
+                      <button class="btn btn-primary" type="submit"><i class="fa fa-search"></i></button>
+                    </span>
+                  </div>
+                </div>
+            </form>
             <ul class="nav navbar-nav navbar-right" id="navbar-avatar-login">
                 <li class="dropdown">
                     {% if user.is_authenticated %}

--- a/mapstory/templates/mapstory/diary_edit.html
+++ b/mapstory/templates/mapstory/diary_edit.html
@@ -33,6 +33,7 @@
 {% endblock %}
 
 {% block extra_script %}
+{{ block.super }}
 <script>
 {# work-around django form output #}
 $("#entry-form .form-group.full input,textarea").addClass("form-control");

--- a/mapstory/templates/people/profile_detail.html
+++ b/mapstory/templates/people/profile_detail.html
@@ -351,6 +351,7 @@ WHAT IS THIS PART?!-->
 {% endblock %}
 
 {% block extra_script %}
+{{ block.super }}
   {% if GEONODE_SECURITY_ENABLED %}
     {% include "_permissions_form_js.html" %}
   {% endif %}

--- a/mapstory/templates/search/searchn.html
+++ b/mapstory/templates/search/searchn.html
@@ -64,6 +64,7 @@
 {% endblock %}
 
 {% block extra_script %}
+  {{ block.super }}
   <script type="text/javascript">
     {% if HAYSTACK_SEARCH %}
     SEARCH_URL = '{% url 'api_get_search' api_name='api' resource_name='base' %}'

--- a/mapstory/templates/site_base.html
+++ b/mapstory/templates/site_base.html
@@ -11,6 +11,30 @@
 {% endif %}
 {% endblock head %}
 
+{% block extra_script %}
+<script type="text/javascript">
+/* Script for keywords autocomplete */
+    var quicksearch_autocomplete = $('#quicksearch').yourlabsAutocomplete({
+          url: '{% url "autocomplete_light_autocomplete" "TagAutocomplete" %}',
+          choiceSelector: 'span',
+          hideAfter: 200,
+          minimumCharacters: 1,
+          appendAutocomplete: $('#quicksearch'),
+          placeholder: gettext('Enter keyword here ...')
+    });
+    $('#quicksearch').bind('selectChoice', function(e, choice, quicksearch_autocomplete) {
+          if(choice[0].children[0] == undefined) {
+              $('#quicksearch').val(choice[0].innerHTML);
+              $scope.keyword_query = choice[0].innerHTML;
+          }
+    });
+    // Fix placeholder text for Quick Search
+    $(function() {
+        $('#quicksearch').attr('placeholder','Quick Search');
+    });
+</script>
+{% endblock %}
+
 {% block header %}
 {% include 'mapstory/_header.html' %}
 {% endblock %}


### PR DESCRIPTION
Closes [Issue #1071](https://github.com/MapStory/mapstory/issues/1071)

Note: Be on the look out for any pages that have Quick Search, and make sure it functions correctly. I used grep to check for all instances of the extra_script block being overwritten, which if it is, it must call {{ block.super }} for quick search to work properly. Just in case I missed one or if there is some other case, we may want to check to be sure.
