### PR TITLE
Added community django model

### DIFF
--- a/mapstory/admin.py
+++ b/mapstory/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django import forms
 
 from mapstory.models import Sponsor
+from mapstory.models import Community
 from mapstory.models import NewsItem
 from mapstory.models import DiaryEntry
 from mapstory.models import GetPage
@@ -51,6 +52,13 @@ class SponsorAdmin(admin.ModelAdmin):
     list_editable = 'name', 'link', 'icon', 'description', 'order'
     list_display_links = 'image_tag',
 
+class CommunityAdmin(admin.ModelAdmin):
+    model = Community
+    exclude = 'stamp',
+    list_display = 'name', 'link', 'icon', 'image_tag', 'description', 'order'
+    list_editable = 'name', 'link', 'icon', 'description', 'order'
+    list_display_links = 'image_tag',
+
 
 class NewsItemForm(forms.ModelForm):
     date = forms.DateTimeField(
@@ -85,6 +93,7 @@ class ParallaxImageAdmin(admin.ModelAdmin):
 admin.site.register(GetPage, GetPageAdmin)
 admin.site.register(GetPageContent, GetPageContentAdmin)
 admin.site.register(Sponsor, SponsorAdmin)
+admin.site.register(Community, CommunityAdmin)
 admin.site.register(NewsItem, NewsItemAdmin)
 admin.site.register(DiaryEntry, DiaryEntryAdmin)
 admin.site.register(Leader, LeaderAdmin)

--- a/mapstory/models.py
+++ b/mapstory/models.py
@@ -41,6 +41,33 @@ class Sponsor(models.Model):
     image_tag.short_description = 'Image'
     image_tag.allow_tags = True
 
+class Community(models.Model):
+    name = models.CharField(max_length=64)
+    link = models.URLField(blank=False)
+    icon = models.ImageField(blank=False, upload_to='communities')
+    description = models.TextField(blank=True)
+    order = models.IntegerField(blank=True, default=0)
+    stamp = models.CharField(max_length=8, blank=True)
+
+    def url(self):
+        return self.icon.url + "?" + self.stamp
+
+    def save(self, *args, **kwargs):
+        if self.icon.name:
+            self.stamp = _stamp(self.icon.read())
+        super(Community, self).save(*args, **kwargs)
+
+    def __unicode__(self):
+        return 'Community - %s' % self.name
+
+    class Meta:
+        ordering = ['order']
+
+    def image_tag(self):
+        return u'<img src="%s" />' % self.url()
+    image_tag.short_description = 'Image'
+    image_tag.allow_tags = True
+
 
 class ContentMixin(models.Model):
     content = models.TextField(
@@ -119,3 +146,6 @@ def get_images():
 
 def get_sponsors():
     return Sponsor.objects.filter(order__gte=0)
+
+def get_communities():
+    return Community.objects.filter(order__gte=0)

--- a/mapstory/templates/index.html
+++ b/mapstory/templates/index.html
@@ -340,16 +340,19 @@
         <div class="container">
             <div class="row">
                 <h1 class="text-center">Community Initiatives</h1>
+                <h3 class="text-center">Our Community Initiative leads are taking on huge data collection tasks, like mapping the history of human settlement and country borders. Click on one below, and start contributing...
+                </h3>
             </div>
             <hr/>
             <div class="row">
                 {% for community in communities %}
                 <div class="col-sm-2">
-                    <img class="rdphoto" src="{{ community.url }}" alt="{{ community.name }} - {{ community.description }}">
+                    <a href="{{ community.link }}">
+                        <img class="rdphoto" src="{{ community.url }}" alt="{{ community.name }} - {{ community.description }}">
+                    </a>
                 </div>
                 {% empty %}
-                <!-- TODO: Update this -->
-                <p>No communities...</p>
+                <p>No Community Initiatives. Add <a href="{% url 'admin:mapstory_community_add' %}">some</a></p>
                 {% endfor %}
             </div>
         </div>
@@ -376,7 +379,7 @@
                     </a>
                 </div>
                 {% empty %}
-                <p>No Sponsors. Add <a href="{% url 'admin:mapstory_sponsor_add' %}">some</a>
+                <p>No Sponsors. Add <a href="{% url 'admin:mapstory_sponsor_add' %}">some</a></p>
                 {% endfor %}
             </div>
         </div>

--- a/mapstory/views.py
+++ b/mapstory/views.py
@@ -21,6 +21,7 @@ from mapstory.models import GetPage
 from mapstory.models import NewsItem
 from mapstory.models import DiaryEntry
 from mapstory.models import Leader
+from mapstory.models import get_communities
 from geonode.base.models import Region
 from geonode.geoserver.helpers import ogc_server_settings
 from urlparse import urlsplit
@@ -36,6 +37,7 @@ class IndexView(TemplateView):
     def get_context_data(self, **kwargs):
         ctx = super(IndexView, self).get_context_data(**kwargs)
         ctx['sponsors'] = get_sponsors()
+        ctx['communities'] = get_communities()
         news_items = NewsItem.objects.filter(date__lte=datetime.datetime.now())
         ctx['news_items'] = news_items[:3]
         ctx['images'] = get_images()


### PR DESCRIPTION
Note: This adds a new django model, so I'm not sure if that may require a restart on paver or something to have it appear.

Perhaps we may want to add a mock community initiative? You should be able to do so exactly the same as with sponsors, only by going through the "Communitys" model instead at /admin/mapstory/community/. @jonpmarino Not sure if some exist and you just wanted to be able to plug them in real quick...

Closes [Issue #1078](https://github.com/MapStory/mapstory/issues/1078)
