### PR TITLE
Fix for missing nouislider css

### DIFF
--- a/mapstory/templates/maps/viewer.html
+++ b/mapstory/templates/maps/viewer.html
@@ -3,7 +3,7 @@
 
 <link rel="stylesheet" href="{{ STATIC_URL }}mapstory/css/ol.css" type="text/css">
 <link rel="stylesheet" href="{{ STATIC_URL }}mapstory/vis/dist/vis.min.css" type="text/css"/>
-<link rel="stylesheet" href="{{ STATIC_URL }}mapstory/css/jquery.css" type="text/css">
+<link rel="stylesheet" href="{{ STATIC_URL }}vendor/nouislider/distribute/jquery.nouislider.min.css" type="text/css">
 
 <script src="{{ STATIC_URL }}mapstory/js/angular.js" ></script>
 <script src="{{ STATIC_URL }}mapstory/js/jquery.min.js"></script>


### PR DESCRIPTION
Note: You may need to run grunt static to be able to pull in the css.
