### PR TITLE
Use the master branch instead of mapstory-v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Prerequisites:
 Repositories
 ------------
 
-The full build lives in a 'meta-project' at https://github.com/MapStory/mapstory/tree/mapstory-v2. This is used for stability as the upstream dependent projects are pegged to specific versions. While MapStory has forks of upstream projects, the goal is to support temporary efforts that are intended for eventual merging into the respective projects. The forks' will be updated as needed.
+The full build lives in a 'meta-project' at https://github.com/MapStory/mapstory/tree/master. This is used for stability as the upstream dependent projects are pegged to specific versions. While MapStory has forks of upstream projects, the goal is to support temporary efforts that are intended for eventual merging into the respective projects. The forks will be updated as needed.
 
 For a local developer build, clone the following repositories as siblings of each other:
 * https://github.com/MapStory/MapLoom

--- a/scripts/provision/vars.yml
+++ b/scripts/provision/vars.yml
@@ -1,6 +1,6 @@
 ---
 pgpass: foobar
-mapstory_branch: mapstory-v2
+mapstory_branch: master
 top_project: /srv/git/mapstory
 mapstory_geonode: '{{ top_project }}/mapstory-geonode'
 geoserver_data: /var/lib/geoserver/data


### PR DESCRIPTION
Based on https://github.com/MapStory/mapstory/issues/1207, mapstory-v2 has been merged into MapStory/master.  This updates the provisioning process to use the master branch.
