### PR TITLE
Slackify excpetions.

### DIFF
--- a/mapstory/settings/__init__.py
+++ b/mapstory/settings/__init__.py
@@ -71,6 +71,7 @@ INSTALLED_APPS += (
     'geonode.contrib.favorite',
     'haystack',
     'mailer',
+    'django_slack',
 )
 
 TEMPLATE_CONTEXT_PROCESSORS += (
@@ -275,3 +276,54 @@ if DATABASE_PASSWORD:
     USE_BIG_DATE = True
 
     GEOGIG_DATASTORE_NAME = 'geogig'
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': True,
+    'formatters': {
+        'verbose': {
+            'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
+        },
+        'simple': {
+            'format': '%(message)s',
+        },
+    },
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse'
+        }
+    },
+    'handlers': {
+        'null': {
+            'level': 'ERROR',
+            'class': 'django.utils.log.NullHandler',
+        },
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'simple'
+        },
+        'mail_admins': {
+            'level': 'ERROR', 'filters': ['require_debug_false'],
+            'class': 'django.utils.log.AdminEmailHandler',
+        },
+        'slack_admins': {
+            'level': 'ERROR',
+            'filters': ['require_debug_false'],
+            'class': 'django_slack.log.SlackExceptionHandler'
+        }
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["console", "slack_admins"], "level": "ERROR", },
+        "mapstory": {
+            "handlers": ["console"], "level": "ERROR", },
+        "gsconfig.catalog": {
+            "handlers": ["console"], "level": "ERROR", },
+        "owslib": {
+            "handlers": ["console"], "level": "ERROR", },
+        "pycsw": {
+            "handlers": ["console"], "level": "ERROR", },
+        },
+    }
+

--- a/mapstory/utils.py
+++ b/mapstory/utils.py
@@ -2,6 +2,7 @@ import os
 import re
 from django.contrib.staticfiles.templatetags import staticfiles
 
+
 class Link(object):
 
     def __init__(self, href, name=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ PasteDeploy
 https://github.com/MapStory/django-maploom/archive/mapstory.zip
 django-haystack==2.4.0
 elasticsearch==1.6.0
+django-slack==4.1.0


### PR DESCRIPTION
<img width="484" alt="screen shot 2015-10-15 at 8 07 53 am" src="https://cloud.githubusercontent.com/assets/1141646/10513193/f448a49c-7313-11e5-8ce0-b9139a4bdcd3.png">

Once merged follow these steps to enable:
1. Add the `slack_admins` handler to the various loggers in the LOGGING dict of settings.py:

```
        "django": {
            "handlers": ["console", "slack_admins"], "level": "ERROR", },
        "mapstory": {
            "handlers": ["console", "slack_admins"], "level": "ERROR", },
```
1. Add the following settings to settings.py:

```
SLACK_BACKEND = 'django_slack.backends.RequestsBackend'
SLACK_TOKEN = '<token>'
SLACK_CHANNEL = '#secure_devops'
SLACK_ICON_EMOJI = ':goberserk:'
SLACK_USERNAME = 'devbot'
```
