### PR TITLE
Added feature to allow admin users to export selected model objects as a CSV file.

### DIFF
--- a/mapstory/export.py
+++ b/mapstory/export.py
@@ -1,0 +1,32 @@
+import csv
+from django.http import HttpResponse
+
+def export_via_model(model, request, queryset, fields=None, exclude=None):
+        opts = model._meta
+        field_names = set([field.name for field in opts.fields])
+        if fields:
+            fieldset = set(fields)
+            field_names = field_names & fieldset
+        elif exclude:
+            excludeset = set(exclude)
+            field_names = field_names - excludeset
+
+        response = HttpResponse(mimetype='text/csv')
+
+        response['Content-Disposition'] = \
+            'attachment; filename=%s.csv' % unicode(opts).replace('.', '_')
+
+        field_names = list(field_names)
+        writer = csv.DictWriter(response, field_names)
+        writer.writer.writerow(field_names)
+
+        for obj in queryset:
+            writer.writerow(
+                dict(
+                    zip(
+                        field_names,
+                        [unicode(getattr(obj, field)).encode("utf-8","replace") for field in field_names]
+                    )
+                )
+            )
+        return response

--- a/mapstory/tests.py
+++ b/mapstory/tests.py
@@ -16,6 +16,8 @@ from mapstory.models import Community, DiaryEntry
 from geonode.people.models import Profile
 import json
 
+from mapstory.export import export_via_model
+
 User = get_user_model()
 
 
@@ -93,6 +95,18 @@ class MapStoryTests(MapStoryTestMixin):
         response = c.get(reverse('search'))
         self.assertEqual(response.status_code, 200)
         self.assertHasGoogleAnalytics(response)
+
+    def test_csv_user_export(self):
+        """
+        Ensure export model returns a csv file
+        """
+        c = Client()
+
+        request = c.get(reverse('index_view'))
+
+        response = export_via_model(User, request, User.objects.all(), exclude=['password'])
+
+        self.assertEqual(response['Content-Type'], 'text/csv')
 
     def test_journal_renders(self):
         """


### PR DESCRIPTION
This is a feature from v1 that I ported over per Jon's request.
- [x] Adds export to CSV for the People Profile model in the Django Admin.
