### PR TITLE
fixed bower ECONFLICT issue with angular*

### DIFF
--- a/mapstory/static/bower.json
+++ b/mapstory/static/bower.json
@@ -21,5 +21,9 @@
     "angular-slick": "https://github.com/MapStory/angular-slick.git#dynamic-data",
     "story-tools": "https://github.com/MapStory/story-tools.git#master",
     "jquery.cookie": "1.4.1"
+  },
+  "resolutions": {
+    "angular": "1.3.0",
+    "angular-bootstrap": "0.9.0"
   }
 }


### PR DESCRIPTION
When running bower on the bower.json file in static dir the following errors caused an exit code to stop the rpmbuild process.

```
bower ECONFLICT     Unable to find suitable version for angular
```

adding a resolution for angular and angular-bootstrap fixed the issue.

Note: only adding a resolution prompted the following error, both have been added to the bower.json

```
bower ECONFLICT     Unable to find suitable version for angular-bootstrap
```
