### PR TITLE
Implemented threaded comments

### DIFF
--- a/mapstory/settings/base.py
+++ b/mapstory/settings/base.py
@@ -72,7 +72,17 @@ INSTALLED_APPS += (
     'haystack',
     'mailer',
     'django_slack',
+    # Adding Threaded Comments app
+    'fluent_comments',
+    'crispy_forms',
+    'threadedcomments',
+    'django_comments',
+    'django.contrib.sites',
 )
+
+# Adding Threaded Comments app
+FLUENT_COMMENTS_EXCLUDE_FIELDS = ('name', 'email', 'url', 'title')
+COMMENTS_APP = 'fluent_comments'
 
 TEMPLATE_CONTEXT_PROCESSORS += (
     'mapstory.context_processors.context',

--- a/mapstory/templates/comments/base.html
+++ b/mapstory/templates/comments/base.html
@@ -1,0 +1,9 @@
+{% load i18n %}
+
+{% block headtitle %}{% block title %}{% trans "Responses for page" %}{% endblock %}{% endblock %}
+
+{% block main %}
+    <div id="comments-wrapper">
+        {% block content %}{% endblock %}
+    </div>
+{% endblock %}

--- a/mapstory/templates/comments/comment.html
+++ b/mapstory/templates/comments/comment.html
@@ -1,0 +1,19 @@
+{% load i18n %}
+{% load comments %}
+{% load fluent_comments_tags %}
+{% load friendly_loader %}
+{% friendly_load avatar_tags %}
+<article class="col-md-12 comment" style="{% if forloop.counter|divisibleby:2 %}background-color: #EEE;{% endif %}">
+  <div class="avatar pull-left"><a href="{{ comment.user.get_absolute_url }}">{% avatar comment.user 40 %}</a></div>
+  <p class="comment-description">
+    {{ comment.comment|linebreaks }}
+      <div class="comment-author">
+        <p style="margin-top: -10px;">{% trans 'By' %} <a href="{{ comment.user.get_absolute_url }}" rel="author">{{ comment.user }}</a> on <time>{{ comment.submit_date|date:"M j, Y" }}</time></p>
+      </div>
+      <!-- Do we want to be able to delete comments?
+      <button type="submit" class="btn btn-danger btn-xs">Delete</button> -->
+      {% if user.is_authenticated %}
+      <a href="#form_post_comment_div{{ comment.id }}" class="btn btn-primary btn-xs" id="c{{ comment.id }}" role="button" data-toggle="collapse">Reply</a>
+      {% endif %}
+  </p>
+</article>

--- a/mapstory/templates/comments/form.html
+++ b/mapstory/templates/comments/form.html
@@ -1,0 +1,20 @@
+{% load comments i18n crispy_forms_tags fluent_comments_tags %}{% load url from future %}
+
+{% if not form.target_object|comments_are_open %}
+    <p>{% trans "Comments are closed." %}</p>
+{% else %}
+    <form id="comment-form-{{ form.target_object.pk }}" data-object-id="{{ form.target_object.pk }}" action="{% comment_form_target %}" method="post" class="{{ form.helper.form_class|default:'js-comments-form comments-form form-horizontal' }}"
+          data-ajax-action="{% url 'comments-post-comment-ajax' %}">
+      {% if next %}<div><input type="hidden" name="next" value="{{ next }}" /></div>{% endif %}
+
+      {% crispy form %}
+
+      <div class="form-group">
+        <div class="col-sm-10">
+          <input type="submit" name="post" class="btn btn-primary" value="{% trans 'Post' %}" />
+          {% comment %} For some reason this only appears by the first form, not sure why? {% endcomment %}
+          {% ajax_comment_tags for form.target_object %}
+        </div>
+      </div>
+    </form>
+{% endif %}

--- a/mapstory/templates/detail_base.html
+++ b/mapstory/templates/detail_base.html
@@ -1,5 +1,6 @@
 {% load i18n %}
-{% load dialogos_tags %}
+{% load comments %}
+{% load fluent_comments_tags %}
 {% load agon_ratings_tags %}
 {% load bootstrap_tags %}
 {% load url from future %}
@@ -55,9 +56,12 @@
           </div>
           <div class="col-sm-10">
             <article id="comments" class="tab-pane">
-              {% with resource as obj %}
-                {% include "_comments.html" %}
-              {% endwith %}
+              {% get_comment_count for resource as num_comments %}
+              {{ num_comments }} comments
+              {% if user.is_authenticated %}
+              {% render_comment_form for resource %}
+              {% endif %}
+              {% render_comment_list for resource %}
             </article>
           </div>
         </div>

--- a/mapstory/templates/fluent_comments/templatetags/threaded_list.html
+++ b/mapstory/templates/fluent_comments/templatetags/threaded_list.html
@@ -1,0 +1,23 @@
+{% comment %}
+
+  The template for threadedcomments, spiced up.
+  This is included via comments/list.html
+
+  The id="comments-..." is required for JavaScript,
+  the 'comments/comment.html template is also used by the Ajax view.
+
+{% endcomment %}
+{% load threadedcomments_tags %}
+<div id="comments-{{ target_object_id }}" data-object-id="{{ target_object_id }}" class="comments {% if not comment_list %} empty{% endif %}">
+    {% for comment in comment_list|fill_tree|annotate_tree %}
+      {% ifchanged comment.parent_id %}{% else %}</li>{% endifchanged %}
+      {% if not comment.open and not comment.close %}</li>{% endif %}
+      {% if comment.open %}<ul class="comment-list-wrapper">{% endif %}
+          <li class="comment-wrapper">
+              {% include "comments/comment.html" %}
+              {% if user.is_authenticated %}
+              <div class="collapse" id="form_post_comment_div{{ comment.id }}">{% render_comment_form for resource with comment.id %}</div>
+              {% endif %}
+          {% for close in comment.close %}</li></ul>{% endfor %}
+    {% endfor %}
+</div>

--- a/mapstory/templates/layers/layer_detail.html
+++ b/mapstory/templates/layers/layer_detail.html
@@ -12,6 +12,7 @@
 {% block title %}{{ resource.title|default:resource.typename }} — {{ block.super }}{% endblock %}
 
 {% block head %}
+<link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}fluent_comments/css/ajaxcomments.css" />
 {% if preview == 'geoext' %}
   {% include "layers/layer_geoext_map.html" %}
 {% else %}
@@ -97,4 +98,5 @@
   {% with include_spatial='true' %}
   {% include 'search/search_scripts.html' %}
   {% endwith %}
+  <script type="text/javascript" src="{{ STATIC_URL }}fluent_comments/js/ajaxcomments.js"></script>
 {% endblock extra_script %}

--- a/mapstory/templates/maps/map_detail.html
+++ b/mapstory/templates/maps/map_detail.html
@@ -11,6 +11,7 @@
 {% block title %}{{ resource.title }} — {{ block.super }}{% endblock %}
 
 {% block head %}
+<link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}fluent_comments/css/ajaxcomments.css" />
 {% include "maps/map_include.html" %}
 {{ block.super }}
 <style type="text/css">
@@ -147,4 +148,5 @@ body.ms-fullscreen .gxp-annotations-tip {
 {% with include_spatial='true' %}
 {% include 'search/search_scripts.html' %}
 {% endwith %}
+<script type="text/javascript" src="{{ STATIC_URL }}fluent_comments/js/ajaxcomments.js"></script>
 {% endblock %}

--- a/mapstory/urls.py
+++ b/mapstory/urls.py
@@ -47,6 +47,10 @@ layer_detail_patterns = patterns('',
     )
 
 urlpatterns = patterns('',
+    # Adding Threaded Comments app
+    url(r'^articles/comments/', include('django_comments.urls')),
+    url(r'^blog/comments/', include('fluent_comments.urls')),
+
     url(r'^$', IndexView.as_view(), name="index_view"),
     url(r'^accounts/profile/$', RedirectView.as_view(url=reverse_lazy('index_view'))), #temp fix for social auth redirect
     url(r"^account/signup/$", MapStorySignup.as_view(), name="account_signup"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,7 @@ oauth2==1.5.211
 #AWS S3 dependencies
 django-storages==1.1.8
 boto==2.38.0
+
+#threaded comments dependencies
+django-threadedcomments==1.0.1
+django-fluent-comments==1.0.5


### PR DESCRIPTION
Threaded comments works now, however, it has some refactoring it could use and is missing tests.

Refactoring:
- Pagination / "load more ..." button for long comment threads. For some reason loading the threadedcomments/fluent_comments django app seems to conflict with loading the endless_pagination django app. Need to resolve the conflict or do it by hand.
- Ajax feedback upon posting a comment is weird. Regular replying works fine. Threaded comments has strange behaviour: upon replying to a threaded comment, the form seems to "jump" to being beneath the first comment, where it will say that your comment has been posted. The form remains existing, but you can't click reply again.
- Including tests: https://github.com/travislbrundage/mapstory-geonode/tree/django-fluentcomments-tests - they rely on MapStoryWorkflowTests which aren't working and are commented out...
