### PR TITLE
Small bugfix for search: removing the last filter item fixed

### DIFF
--- a/mapstory/static/mapstory/js/search.js
+++ b/mapstory/static/mapstory/js/search.js
@@ -224,7 +224,7 @@
             $scope.type__in = $location.search()['type__in'].replace(/\W+/g," ");
           }
           // Filter by Regions
-          if ($location.search().hasOwnProperty('regions')) {
+          if ($location.search().hasOwnProperty('regions') && $location.search()['regions'].length > 0) {
             $scope.results = data.objects.filter(function(value) {
               for (var index = 0; index < value.regions.length; index++) {
                 if ($location.search()['regions'].indexOf(value.regions[index]) > -1) {
@@ -234,7 +234,7 @@
             });
           }
           // Filter by Keywords
-          if ($location.search().hasOwnProperty('keywords')) {
+          if ($location.search().hasOwnProperty('keywords') && $location.search()['keywords'].length > 0) {
             $scope.results = data.objects.filter(function(value) {
               for (var index = 0; index < value.keywords.length; index++) {
                 if ($location.search()['keywords'].indexOf(value.keywords[index]) > -1) {


### PR DESCRIPTION
Only filters by this query if there actually is one (the property can exist with 0 elements, previously it was getting nothing if the filter had no elements, which occurred by adding and removing them).
