### PR TITLE
Organizations and Initiatives clean up and tests

### DIFF
--- a/mapstory/forms.py
+++ b/mapstory/forms.py
@@ -7,6 +7,8 @@ from geonode.layers.models import Layer
 from geonode.base.forms import Profile
 from geonode.base.models import ResourceBase
 import taggit
+from geonode.groups.models import GroupProfile
+from geonode.groups.forms import GroupForm, GroupUpdateForm
 
 class MapStorySignupForm(SignupForm):
     """
@@ -145,3 +147,17 @@ class EditProfileForm(forms.ModelForm):
     class Meta:
         model = Profile
         fields = ['first_name', 'last_name', 'keywords', 'city', 'country', 'profile', 'education', 'expertise', 'social_twitter', 'social_facebook', 'social_linkedin', 'social_github', 'Volunteer_Technical_Community']
+
+# Organization forms
+class OrganizationForm(GroupForm):
+
+    class Meta:
+        model = GroupProfile
+        exclude = ['group', 'profile_type', 'tasks']
+
+
+class OrganizationUpdateForm(GroupUpdateForm):
+
+    class Meta:
+        model = GroupProfile
+        exclude = ['group', 'profile_type', 'tasks']

--- a/mapstory/static/mapstory/js/mapstory.js
+++ b/mapstory/static/mapstory/js/mapstory.js
@@ -405,10 +405,12 @@
       }
       $scope.avatar = data.group.logo;
       $scope.title = data.group.title;
+      document.title = $scope.title;
       $scope.slug = data.group.slug;
       // grab only the media names
       $scope.facebook = data.group.social_facebook.split('/')[1];
       $scope.twitter = data.group.social_twitter.split('/')[1];
+      $scope.tasks = data.group.tasks;
       $scope.interests = data.group.keywords;
       $scope.summary = data.group.description;
       $scope.city = data.group.city;

--- a/mapstory/templates/mapstory/initiative_detail.html
+++ b/mapstory/templates/mapstory/initiative_detail.html
@@ -6,16 +6,17 @@
 {% load mapstory_tags %}
 {% load cache %}
 {% load avatar_tags %}
+{% load threadedcomments_tags %}
+{% load fluent_comments_tags %}
 
 {% block extra_head %}
 <link href="{{ STATIC_URL }}mapstory/css/search.css" rel="stylesheet" />
 {% endblock %}
 
-{% block title %}{{ community.name }}{% endblock %}
-
 {% block middle %}
-<div ng-app="paginate"><div ng-controller="paginate_controller">
-        <!-- content -->
+<div ng-controller="collection_controller">
+        <div ng-init="query({{id}})">
+        </div>
         <section class="parallax">
           <div data-stellar-background-ratio="0.5" data-stellar-vertical-offset="0" style="background-image: url({{ images|by_name:'Africa' }}); background-size: 100%; background-position: 0% 20%;">
             <div class="maskParent">
@@ -23,12 +24,15 @@
               <div class="paralaxText container" style="text-align:left;padding-bottom:0">
                 <div class="row">
                   <div class="col-sm-1">
-                    <img class="img-rounded" src="{{ community.url }}" width="75" height="75" style="margin-top:55px;margin-bottom:0px"/>
-                    
+                    {% verbatim %}
+                    <img class="img-rounded" src="{{ avatar }}" width="75" height="75" style="margin-top:55px;margin-bottom:0px" ng-if="avatar"/>
+                    {% endverbatim %}
                   </div>
                   <div class="col-sm-11">
                     <div style="padding:60px 0px 0px 10px;">
-                      <h1 style="font-size:3em; color: white;">{{ community.name }}</h1>
+                      {% verbatim %}
+                      <h1 style="font-size:3em; color: white;">{{ title }}</h1>
+                      {% endverbatim %}
                     </div>
                   </div>
                  </div>
@@ -36,79 +40,146 @@
            </div>
           </div>
         </section>
-        <!-- dashboard -->
         <section class="slice" id="dashboard" style="padding-top:20px">
           <div class="container">
             <div class="row" >
               <div class="col-lg-3" style="padding-top:10px">
                 <h3>
-                  <span>Help lead this initiative! Send a message to one of the current Initiative Leads</span>
+                  {% if managers %}
+                  <span id="send-message-manager">Help lead this initiative! <br/><a href='{% url "message_create" user_id=managers.0.pk %}'><span style="color:orange">Send a message</span></a> to the Initiative Leader</span>
+                    {% for manager in managers %}
+                      {% ifequal manager user %}
+                      <script>
+                      // Hide the message button if we're a manager
+                      document.getElementById("send-message-manager").style.display = "none";
+                      </script>
+                      {% verbatim %}
+                      <a href='/initiatives/members/{{ slug }}'><span style="color:orange">manage members</span></a>
+                      {% endverbatim %}
+                      {% endifequal %}
+                    {% endfor %}
+                  {% else %}
+                  Help lead this initiative! <br/><a href='{% url "message_create" %}'><span style="color:orange">Send a message</span></a> to the Initiative Leader
+                  {% endif %}
                 </h3>
-                          </div>
-                          <div class="col-lg-9" style="border-left:1px solid darkgray">
+
+                <hr style="margin:5px">
+                {% verbatim %}
+                <h3 ng-if="facebook">
+                  <span style="color:dodgerblue">facebook.com/{{ facebook }}</span>
+                </h3>
+                <hr style="margin:5px" ng-if="facebook">
+                <h3 ng-if="twitter">
+                  <span style="color:deepskyblue">twitter @{{ twitter }}</span>
+                </h3>
+                <hr style="margin:5px" ng-if="twitter">
+                {% endverbatim %}
+              </div>
+              <div class="col-lg-9" style="border-left:1px solid darkgray">
                 <ul class="nav nav-tabs">
                     <li  class="active"><a href="#guidelines" data-toggle="tab">Overview &<br/> Guidelines</a></li>
                     <li><a href="#tasks" data-toggle="tab">Tasks &<br/> Milestones</a></li>
                     <li><a href="#storylayers" data-toggle="tab">StoryLayers<br/>List</a></li>
-                  <li><a href="#mapstories" data-toggle="tab">Favorited <br/>MapStories</a></li>
+                    <li><a href="#mapstories" data-toggle="tab">Favorited<br/>MapStories</a></li>
                     <li><a href="#leads" data-toggle="tab">Initiative <br/>Leads</a></li>
                     <li><a href="#blogs" data-toggle="tab">Journal<br/>Entries</a></li>
                 </ul>
                 <div class="tab-content">
-                  <!-- TODO: Hook in favorites here -->
-                  <div class="tab-pane" id="mapstories">
-                    <div class="container">
-                      
-                    </div>
-                  </div>
                   <div class="tab-pane" id="tasks">
                     <div class="container">
-                      <ul>
-                        {% for task in community.tasks.all %}
-                          <li>
-                          {{ task.task }}
-                          </li>
-                        {% empty %}
-                        There are no tasks for this initiative.
-                        {% endfor %}
-                      </ul>
+                      <!-- TODO: This is supposed to be a list of many text items... but why? Some interaction here? -->
+                      {% verbatim %}
+                      <p>{{ tasks }}</p>
+                      <p ng-if="!tasks">There are no tasks for this initiative.</p>
+                      {% endverbatim %}
                     </div>
                   </div>
                   <div class="tab-pane active" id="guidelines">
-                      {{ community.description }}
+                    {% verbatim %}
+                      {{ summary }}
+                    {% endverbatim %}
                   </div>
                   <div class="tab-pane" id="storylayers">
                     <div class="col-lg-12">
                       <div class="clearfix search-results">
                         <ul>
-                          {% for layer in community.layer.all %}
-                          <li class="col-md-4">
+                          {% verbatim %}
+                          <li ng-repeat="item in layers" resource_id="{{ item.id}}" class="col-md-4">
                             <div style="text-align: left; height: 500px;">
-                              <a href="{{ layer.detail_url}}"><img class="thumb img-responsive" src="{{ layer.thumbnail_url}}"/></a>
-                              <h3><a href="{{ layer.detail_url}}">{{ layer.title}}</a></h3>
-                              <div><p><i>StoryLayer</p></i></div>
-                              <h4><span class="owner"><i class="fa fa-user"></i>{{ layer.owner.first_name }} {{ layer.owner.last_name }}</span></h4>
-                              <h4><span><i class="fa fa-flag-o"></i></span>{{ layer.category.gn_description}}</h4>
-                              <!-- TODO: Hook in the edits -->
-                              <h4><a href="{{ layer.detail_url}}"><i class="fa fa-pencil"></i> edits</a></h4>
-                              <h4><a href="{{ layer.detail_url}}#rate"><i class="fa fa-star"></i> {{ layer.rating}}</a></h4>
-                              <div><h5 class="abstract"><a href="#">{{ layer.abstract|slice:"70" }}<i>...read more</i></a></h5></div>
-                              <div class="btn-toolbar">
-                                <h4>
-                                  <!-- goes to composer -->
-                                  <a href="{% url "new_map" %}?layer={{ layer.detail_url|slice:"8:" }}"><button class="btn btn-primary btn-xs"><i class="fa fa-play"></i> use</button></a>
-                                  <!-- goes to layer edit -->
-                                  <a href='{% url "map-edit" %}?layer={{layer.service_typename}}'><button class="btn btn-primary btn-xs"><i class="fa fa-share-alt"></i> edit</button></a>
-                                  <!-- TODO: Hook in favorites functionality -->
-                                  <button class="btn btn-primary btn-xs"><i class="fa fa-heart-o"></i> favorite</button>
-                                </h4>
-                              </div>
+                                <a href="{{ item.detail_url}}"><img class="thumb img-responsive" ng-src="{{ item.thumbnail_url | decodeURIComponent }}"/></a>
+                                <h3><a href="{{ item.detail_url}}">{{ item.title}}</a></h3>
+                                <div>
+                                  <p>
+                                    <i>StoryLayer</i>
+                                  </p>
+                                </div>
+                                <h4> Created {{ item.date|date }}</h4>
+                                <h4 ng-if="item.owner__first_name || item.owner__last_name"><span class="owner"><i class="fa fa-user"></i> {{ item.owner__first_name }} {{ item.owner__last_name }}</span></h4>
+                                <h4 style="text-transform: capitalize;"><span><i class="fa fa-flag-o"></i></span> <span>{{ item.category }}</span><span ng-if="!item.category">Uncategorized</span></h4>
+                                <h4><a href="{{ item.detail_url}}"><i class="fa fa-eye"></i> {{ item.popular_count}} views</a></h4>
+                                <h4><a href="{{ item.detail_url}}#rate"><i class="fa fa-star"></i> {{ item.rating}}</a></h4>
+                                <div><h5 class="abstract">{{ item.abstract|limitTo:70 }}<a href="{{ item.detail_url}}"> <i>...read more</i></a></h5></div>
+                                <div class="btn-toolbar">
+                                    <h4>
+                                        <!-- goes to composer -->
+                                        <a href="/maps/new?layer={{ item.detail_url.substring(8) | decodeURIComponent }}"><button class="btn btn-primary btn-xs"><i class="fa fa-play"></i> use</button></a>
+                                        <!-- goes to layer edit -->
+                                        <a href='/maps/edit?layer={{ item.detail_url.substring(8) | decodeURIComponent }}'><button class="btn btn-primary btn-xs"><i class="fa fa-share-alt"></i> edit</button></a>
+                                        <!-- TODO: Hook in favorites functionality -->
+                                        <!-- <button class="btn btn-primary btn-xs" id="favoriteLink"><i class="fa fa-heart-o"></i> favorite</button> -->
+                                    </h4>
+                                </div>
                             </div>
                           </li>
-                          {% empty %}
-                          There are no layers for this initiative.
-                          {% endfor %}
+                          <p ng-if="layers.length == 0">There are no layers made by this initiative.</p>
+                          {% endverbatim %}
                         </ul>
+                      </div>
+                      <span>Total: </span>
+                      <span ng-bind="total_counts"></span>
+                      <a href><strong ng-click="paginate_down()">&laquo;</strong></a>
+                      <span>page </span>
+                      <span ng-model="page" ng-bind="page"></span>
+                      <span> of </span>
+                      <span ng-bind="numpages"></span>
+                      <a href><strong ng-click="paginate_up()">&raquo;</strong></a>
+                    </div>
+                  </div>
+                  <div class="tab-pane" id="mapstories">
+                    <div class="col-lg-12">
+                      <div class="clearfix search-results">
+                        <ul>
+                          {% verbatim %}
+                          <li ng-repeat="item in maps" resource_id="{{ item.id}}" class="col-md-4">
+                            <div style="text-align: left; height: 500px;">
+                                <a href="{{ item.detail_url}}"><img class="thumb img-responsive" ng-src="{{ item.thumbnail_url | decodeURIComponent }}"/></a>
+                                <h3><a href="{{ item.detail_url}}">{{ item.title}}</a></h3>
+                                <div>
+                                  <p>
+                                    <i>MapStory</i>
+                                  </p>
+                                </div>
+                                <h4> Created {{ item.date|date }}</h4>
+                                <h4 ng-if="item.owner__first_name || item.owner__last_name"><span class="owner"><i class="fa fa-user"></i> {{ item.owner__first_name }} {{ item.owner__last_name }}</span></h4>
+                                <h4 style="text-transform: capitalize;"><span><i class="fa fa-flag-o"></i></span> <span>{{ item.category }}</span><span ng-if="!item.category">Uncategorized</span></h4>
+                                <h4><a href="{{ item.detail_url}}"><i class="fa fa-eye"></i> {{ item.popular_count}} views</a></h4>
+                                <h4><a href="{{ item.detail_url}}#rate"><i class="fa fa-star"></i> {{ item.rating}}</a></h4>
+                                <div><h5 class="abstract">{{ item.abstract|limitTo:70 }}<a href="{{ item.detail_url}}"> <i>...read more</i></a></h5></div>
+                                <div class="btn-toolbar">
+                                    <h4>
+                                        <!-- goes to the viewer -->
+                                        <a href="/maps/{{ item.id }}/viewer"><button class="btn btn-primary btn-xs"><i class="fa fa-play"></i> play</button></a>
+                                        <!-- TODO: Hook in favorites functionality -->
+                                        <!-- <button class="btn btn-primary btn-xs" id="favoriteLink"><i class="fa fa-heart-o"></i> favorite</button> -->
+                                        <!-- TODO: Hook in share functionality -->
+                                        <!-- <button class="btn btn-primary btn-xs"><i class="fa fa-share-alt"></i> share</button> -->
+                                    </h4>
+                                </div>
+                            </div>
+                          </li>
+                        </ul>
+                        <p ng-if="maps.length == 0">There are no mapstories made by this initiative.</p>
+                        {% endverbatim %}
                       </div>
                       <span>Total: </span>
                       <span ng-bind="total_counts"></span>
@@ -122,32 +193,33 @@
                   </div>
                   <div class="tab-pane" id="leads">
                     <div class="col-lg-12">
-                      <div class="clearfix search-results">
+                     <div class="clearfix search-results">
                         <ul>
-                          {% for lead in community.leads.all %}
+                          {% for manager in managers %}
                             <li class="col-md-4">
                               <div style="text-align: left;">
-                                  <a href="{{ lead.profile_detail_url}}"><img class="thumb img-responsive img-circle" ng-src="{{ lead.avatar_100}}" src="http://www.gravatar.com/avatar/b3770ff767657838215cefd0d00e7769/?s=100"/></a>
-                                  <h3><a href="{{ lead.profile_detail_url}}">{{ lead.first_name }} {{ lead.last_name }}</a></h3>
+                                  <a href="{{ manager.profile_detail_url}}"><img class="thumb img-responsive img-circle" ng-src="{{ manager.avatar_100}}" src="http://www.gravatar.com/avatar/b3770ff767657838215cefd0d00e7769/?s=100"/></a>
+                                  <h3><a href="{{ manager.profile_detail_url}}">{{ manager.first_name }} {{ manager.last_name }}</a></h3>
                                   <!-- If both exist, comma separated... otherwise no comma separation -->
-                                  {% if lead.position and lead.organization %}
-                                    <h4><i class="fa fa-briefcase"></i>{{ lead.position }}, {{ lead.organization }}</h4>
+                                  {% if manager.position and manager.organization %}
+                                    <h4><i class="fa fa-briefcase"></i>{{ manager.position }}, {{ manager.organization }}</h4>
                                   {% else %}
-                                    {% if lead.position or lead.organization %}
-                                      <h4><i class="fa briefcase"></i>{{ lead.position }} {{ lead.organization }}</h4>
+                                    {% if manager.position or manager.organization %}
+                                      <h4><i class="fa briefcase"></i>{{ manager.position }} {{ manager.organization }}</h4>
                                     {% endif %}
                                   {% endif %}
-                                  {% if lead.city and lead.country %}
-                                    <h4><i class="fa fa-map-marker"></i>{{ lead.city }}, {{ lead.country }}</h4>
+                                  {% if manager.city and manager.country %}
+                                    <h4><i class="fa fa-map-marker"></i>{{ manager.city }}, {{ manager.country }}</h4>
                                   {% else %}
-                                    {% if lead.city or lead.country %}
-                                      <h4><i class="fa fa-map-marker"></i>{{ lead.city }} {{ lead.country }}</h4>
+                                    {% if manager.city or manager.country %}
+                                      <h4><i class="fa fa-map-marker"></i>{{ manager.city }} {{ manager.country }}</h4>
                                     {% endif %}
                                   {% endif %}
-                                  <h4>{{ lead.profile }}</h4>
-
-                                  <a href="{{ lead.profile_detail_url }}"><button class="btn btn-primary btn-xs"><i class="fa fa-user"></i> view profile</button></a>
-                                  <!-- TODO: Hook in messaging functionality -->
+                                  {% if manager.profile %}
+                                  <h4>{{ manager.profile }}</h4>
+                                  {% endif %}
+ 
+                                  <a href="{{ manager.profile_detail_url }}"><button class="btn btn-primary btn-xs"><i class="fa fa-user"></i> view profile</button></a>
                                   <a><button class="btn btn-primary btn-xs"><i class="fa fa-envelope"></i> message</button></a>
                               </div>
                             </li>
@@ -159,42 +231,53 @@
                     </div>
                   </div>
                   <div class="tab-pane" id="blogs">
-                    <div class="col-lg-12">
-                      {% for entry in community.journals.all %}
-                        <div class="row blog-panel">
-                            <div class="col-sm-12">
-                                <div class="row">
-                                    <div class="col-lg-10 col-lg-offset-2  col-xs-12 blog-header">
-                                        <h5 class="blog-title">{{ entry.date }}</h5>
-                                        <h2 class="blog-title"><a href="{{ entry.get_absolute_url }}">{{ entry.title }}</a></h2>
-                                        <h5 class="blog-title">{% avatar entry.author 30 %} {{ entry.author }}</h5>
-                                    </div>
+                    {% if not journals %}
+                    <p>There are no journals for this initiative.</p>
+                    {% endif %}
+                    {% for entry in journals %}
+                    <div class="row blog-panel">
+                        <div class="col-sm-12">
+                            <div class="row">
+                                <div class="col-lg-10 col-lg-offset-2  col-xs-12">
+                                    <h5 class="blog-title">{{ entry.date }}</h5>
+                                    <h1 class="blog-title"><a href="{{ entry.get_absolute_url }}">{{ entry.title }}</a></h2>
+                                    <h5 class="blog-title"><a href="{% url "profile_detail" slug=entry.author.username %}">{% avatar entry.author 30 %} {{ entry.author.first_name }} {{ entry.author.last_name }}</a></h5>
                                 </div>
-                                <div class="row">
-                                    <div class="col-lg-2 col-xs-6 qlink-right">
-                                        <div class="qlink qlink-gen"><a href="#">comment</a></div>
-                                        <div class="qlink qlink-gen"><a href="#">favorite</a></div>
-                                        <div class="qlink qlink-fb"><a href="#">facebook</a></div>
-                                        <div class="qlink qlink-tw"><a href="#">twitter</a></div>
-                                        <div class="qlink qlink-dg"><a href="#">flag/report</a></div>
-                                    </div>
-                                    <div class="col-lg-10 col-xs-6 blog-content bl">
-                                        {{ entry.html|safe }}
-                                    </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-lg-2 col-xs-6 qlink-right">
+                                </div>
+                                <div class="col-lg-8 col-xs-6 blog-content bl">
+                                    {{ entry.html|safe }}
+                                </div>
+                                <div class="col-lg-2 col-xs-6">
+                                    {% ifequal entry.author request.user %}
+                                        <a href="{% url 'diary-update' pk=entry.pk %}">
+                                            <button class="btn btn-primary" aria-hidden="true" id="published_submit_btn" type="submit">{% trans "Edit" %}</button>
+                                        </a>
+                                    {% endifequal %}
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-lg-2 col-xs-6 qlink-right">
+                                </div>
+                                <div class="col-lg-8 col-xs-6 blog-content bl">
+                                    {% get_comment_count for entry as num_comments %}
+                                    {{ num_comments }} comments
+                                    {% if user.is_authenticated %}
+                                    <a href="{{ entry.get_absolute_url }}" class="btn btn-primary btn-xs" role="button">Reply</a>
+                                    {% endif %}
                                 </div>
                             </div>
                         </div>
-                      {% empty %}
-                      <p>There are no journals for this initiative.</p>
-                      {% endfor %}
                     </div>
+                    {% endfor %}
                   </div>
                 </div>
               </div>
             </div>
           </div>
         </section>
-        <!-- dashboard -->
 </div></div>
 {% endblock %}
 {% block extra_script %}

--- a/mapstory/templates/mapstory/initiative_members.html
+++ b/mapstory/templates/mapstory/initiative_members.html
@@ -1,0 +1,127 @@
+{% extends "groups/group_base.html" %}
+{% load i18n %}
+{% load bootstrap_tags %}
+
+{% block sidebar %}
+<div class="row">
+  <div class="col-md-12">
+    <h2 class="page-header">{%  trans "Edit Members for"  %} <a href="{% url "initiative_detail" group.slug %}">{{ group.title }}</a></h2>
+    <h2 class="page-title">{%  trans "Members" %}</h2>
+    <div class="row">
+      <div class="col-md-12">
+        <ul class="nav nav-tabs">
+          <li class="active"><a href="#all" data-toggle="tab"><i class=""></i>{% trans "All" %}</a></li>
+          <li><a href="#managers" data-toggle="tab"><i class=""></i> {% trans "Managers" %}</a></li>
+          <li><a href="#members" data-toggle="tab"><i class=""></i> {% trans "Members" %}</a></li>
+        </ul>
+        <div class="tab-content">
+          <article id="all" class="tab-pane active">
+            <ul class="no-style-list">
+            {% for member in members %}
+              <h4>
+                <i class="fa fa-user"></i> <a href="{{ member.user.get_absolute_url }}">{{ member.user.username }}</a>
+                {% if member.user.email %}
+                <a href="mailto:{{ member.user.email }}"><i class="fa fa-envelope-o"></i></a>
+                {% endif %}
+                |
+                {% if member.role == 'manager' %}
+                  <span class="btn btn-primary btn-xs">{% trans 'Manager' %}</span>
+                  |
+                {% endif %}
+                <form style="display: inline;" method="POST" action="{% url "initiative_member_remove" group.slug member.user.username %}">
+                  {% csrf_token %}
+                  <button type="submit" class="btn btn-danger btn-xs">{% trans 'Remove' %}</button>
+                </form>
+              <h4>
+              <h5>
+                  {% trans 'Role' %}: {{ member.role }}
+              </h5>
+              <hr>
+            {% endfor %}
+            </ul>
+          </article>
+          <article id="managers" class="tab-pane">
+            <ul class="no-style-list">
+            {% for member in members %}
+              {% if member.role = 'manager' %}
+              <h4>
+                <i class="fa fa-user"></i> <a href="{{ member.user.get_absolute_url }}">{{ member.user.username }}</a>
+                {% if member.user.email %}
+                <a href="mailto:{{ member.user.email }}"><i class="fa fa-envelope-o"></i></a>
+                {% endif %}
+                |
+                {% if member.role == 'manager' %}
+                  <span class="btn btn-primary btn-xs">{% trans 'Manager' %}</span>
+                  |
+                {% endif %}
+                <form style="display: inline;" method="POST" action="{% url "initiative_member_remove" group.slug member.user.username %}">
+                  {% csrf_token %}
+                  <button type="submit" class="btn btn-danger btn-xs">{% trans 'Remove' %}</button>
+                </form>
+              <h4>
+              <h5>
+                  {% trans 'Role' %}: {{ member.role }}
+              </h5>
+              <hr>
+              {% endif %}
+            {% endfor %}
+            </ul>
+          </article>
+          <article id="members" class="tab-pane">
+            <ul class="no-style-list">
+            {% for member in members %}
+              {% if member.role = 'member' %}
+              <h4>
+                <i class="fa fa-user"></i> <a href="{{ member.user.get_absolute_url }}">{{ member.user.username }}</a>
+                {% if member.user.email %}
+                <a href="mailto:{{ member.user.email }}"><i class="fa fa-envelope-o"></i></a>
+                {% endif %}
+                |
+                {% if member.role == 'manager' %}
+                  <span class="btn btn-primary btn-xs">{% trans 'Manager' %}</span>
+                  |
+                {% endif %}
+                <form style="display: inline;" method="POST" action="{% url "initiative_member_remove" group.slug member.user.username %}">
+                  {% csrf_token %}
+                  <button type="submit" class="btn btn-danger btn-xs">{% trans 'Remove' %}</button>
+                </form>
+              <h4>
+              <h5>
+                  {% trans 'Role' %}: {{ member.role }}
+              </h5>
+              <hr>
+              {% endif %}
+            {% endfor %}
+            </ul>
+          </article>
+        </div>
+        {% if member_form %}
+          <h2>{% trans "Add members" %}</h2>
+          <form class="uniForm" method="POST" action="{% url "initiative_members_add" group.slug %}">
+            {% csrf_token %}
+            <div id="member_form_container">
+              {{ member_form|as_bootstrap }}<br/><br/>
+            </div>
+            <input type="submit" value="Add Group Members" class="btn btn-success"/>
+          </form>
+        {% endif %}
+
+        {% if invite_form %}
+          <h2>{% trans "Invite people" %}</h2>
+          <form class="uniForm" method="POST" action="{% url "initiative_invite" group.slug %}">
+            {% csrf_token %}
+            {{ invite_form|as_bootstrap }}
+            <input type="submit" value="invite" />
+          </form>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block extra_script %}
+{% with "none" as layer %}
+{% include "_permissions_form_js.html" %}
+{% endwith %}
+{% endblock extra_script %}

--- a/mapstory/templates/mapstory/organization_detail.html
+++ b/mapstory/templates/mapstory/organization_detail.html
@@ -13,15 +13,11 @@
 <link href="{{ STATIC_URL }}mapstory/css/search.css" rel="stylesheet" />
 {% endblock %}
 
-{% block title %}{{ groupprofile.title }}{% endblock %}
-
 {% block body_outer %}
 <div ng-controller="collection_controller">
-        <!-- content -->
         <div ng-init="query({{id}})">
         </div>
         <section class="parallax">
-          <!-- TODO: This doesn't look very good -->
           <div data-stellar-background-ratio="0.5" data-stellar-vertical-offset="0" style="background-image: url({{ images|by_name:'Africa' }}); background-size: 100%; background-position: 0% 20%;">
             <div class="maskParent">
               <div class="paralaxMask"></div>
@@ -76,7 +72,6 @@
            </div>
           </div>
         </section>
-        <!-- dashboard -->
         <section class="slice" id="dashboard" style="padding-top:20px">
           <div class="container">
             <div class="row" >
@@ -91,7 +86,8 @@
                       document.getElementById("send-message-manager").style.display = "none";
                       </script>
                       {% verbatim %}
-                      <a href='/organizations/edit/{{ slug }}'><span style="color:orange">edit org page</span></a>
+                      <a href='/organizations/edit/{{ slug }}'><span style="color:orange">edit org page</span></a><br/><br/>
+                      <a href='/organizations/members/{{ slug }}'><span style="color:orange">manage members</span></a>
                       {% endverbatim %}
                       {% endifequal %}
                     {% endfor %}
@@ -166,7 +162,7 @@
                                 </div>
                             </div>
                           </li>
-                          <p ng-if="!maps">There are no mapstories made by this group.</p>
+                          <p ng-if="org_maps.length == 0">There are no mapstories made by this organization.</p>
                           {% endverbatim %}
                         </ul>
                       </div>
@@ -212,7 +208,7 @@
                                 </div>
                             </div>
                           </li>
-                          <p ng-if="!layers">There are no layers made by this group.</p>
+                          <p ng-if="org_layers.length == 0">There are no layers made by this organization.</p>
                           {% endverbatim %}
                         </ul>
                       </div>
@@ -246,7 +242,7 @@
                                   <a href="/messages/create/{{ user.id }}/"><button class="btn btn-primary btn-xs"><i class="fa fa-envelope"></i> message </button></a>
                               </div>
                           </li>
-                          <p ng-if="!storytellers">There are no members in this group.</p>
+                          <p ng-if="!storytellers">There are no members in this organization.</p>
                           {% endverbatim %}
                         </ul>
                       </div>
@@ -254,7 +250,7 @@
                   </div>
                   <div class="tab-pane" id="blogs">
                     {% if not journals %}
-                    <h2>No Journal Entries Yet :(</h2>
+                    <p>There are no journals for this organization.</p>
                     {% endif %}
                     {% for entry in journals %}
                     <div class="row blog-panel">

--- a/mapstory/templates/mapstory/organization_members.html
+++ b/mapstory/templates/mapstory/organization_members.html
@@ -1,0 +1,127 @@
+{% extends "groups/group_base.html" %}
+{% load i18n %}
+{% load bootstrap_tags %}
+
+{% block sidebar %}
+<div class="row">
+  <div class="col-md-12">
+    <h2 class="page-header">{%  trans "Edit Members for"  %} <a href="{% url "organization_detail" group.slug %}">{{ group.title }}</a></h2>
+    <h2 class="page-title">{%  trans "Members" %}</h2>
+    <div class="row">
+      <div class="col-md-12">
+        <ul class="nav nav-tabs">
+          <li class="active"><a href="#all" data-toggle="tab"><i class=""></i>{% trans "All" %}</a></li>
+          <li><a href="#managers" data-toggle="tab"><i class=""></i> {% trans "Managers" %}</a></li>
+          <li><a href="#members" data-toggle="tab"><i class=""></i> {% trans "Members" %}</a></li>
+        </ul>
+        <div class="tab-content">
+          <article id="all" class="tab-pane active">
+            <ul class="no-style-list">
+            {% for member in members %}
+              <h4>
+                <i class="fa fa-user"></i> <a href="{{ member.user.get_absolute_url }}">{{ member.user.username }}</a>
+                {% if member.user.email %}
+                <a href="mailto:{{ member.user.email }}"><i class="fa fa-envelope-o"></i></a>
+                {% endif %}
+                |
+                {% if member.role == 'manager' %}
+                  <span class="btn btn-primary btn-xs">{% trans 'Manager' %}</span>
+                  |
+                {% endif %}
+                <form style="display: inline;" method="POST" action="{% url "organization_member_remove" group.slug member.user.username %}">
+                  {% csrf_token %}
+                  <button type="submit" class="btn btn-danger btn-xs">{% trans 'Remove' %}</button>
+                </form>
+              <h4>
+              <h5>
+                  {% trans 'Role' %}: {{ member.role }}
+              </h5>
+              <hr>
+            {% endfor %}
+            </ul>
+          </article>
+          <article id="managers" class="tab-pane">
+            <ul class="no-style-list">
+            {% for member in members %}
+              {% if member.role = 'manager' %}
+              <h4>
+                <i class="fa fa-user"></i> <a href="{{ member.user.get_absolute_url }}">{{ member.user.username }}</a>
+                {% if member.user.email %}
+                <a href="mailto:{{ member.user.email }}"><i class="fa fa-envelope-o"></i></a>
+                {% endif %}
+                |
+                {% if member.role == 'manager' %}
+                  <span class="btn btn-primary btn-xs">{% trans 'Manager' %}</span>
+                  |
+                {% endif %}
+                <form style="display: inline;" method="POST" action="{% url "organization_member_remove" group.slug member.user.username %}">
+                  {% csrf_token %}
+                  <button type="submit" class="btn btn-danger btn-xs">{% trans 'Remove' %}</button>
+                </form>
+              <h4>
+              <h5>
+                  {% trans 'Role' %}: {{ member.role }}
+              </h5>
+              <hr>
+              {% endif %}
+            {% endfor %}
+            </ul>
+          </article>
+          <article id="members" class="tab-pane">
+            <ul class="no-style-list">
+            {% for member in members %}
+              {% if member.role = 'member' %}
+              <h4>
+                <i class="fa fa-user"></i> <a href="{{ member.user.get_absolute_url }}">{{ member.user.username }}</a>
+                {% if member.user.email %}
+                <a href="mailto:{{ member.user.email }}"><i class="fa fa-envelope-o"></i></a>
+                {% endif %}
+                |
+                {% if member.role == 'manager' %}
+                  <span class="btn btn-primary btn-xs">{% trans 'Manager' %}</span>
+                  |
+                {% endif %}
+                <form style="display: inline;" method="POST" action="{% url "organization_member_remove" group.slug member.user.username %}">
+                  {% csrf_token %}
+                  <button type="submit" class="btn btn-danger btn-xs">{% trans 'Remove' %}</button>
+                </form>
+              <h4>
+              <h5>
+                  {% trans 'Role' %}: {{ member.role }}
+              </h5>
+              <hr>
+              {% endif %}
+            {% endfor %}
+            </ul>
+          </article>
+        </div>
+        {% if member_form %}
+          <h2>{% trans "Add members" %}</h2>
+          <form class="uniForm" method="POST" action="{% url "organization_members_add" group.slug %}">
+            {% csrf_token %}
+            <div id="member_form_container">
+              {{ member_form|as_bootstrap }}<br/><br/>
+            </div>
+            <input type="submit" value="Add Group Members" class="btn btn-success"/>
+          </form>
+        {% endif %}
+
+        {% if invite_form %}
+          <h2>{% trans "Invite people" %}</h2>
+          <form class="uniForm" method="POST" action="{% url "organization_invite" group.slug %}">
+            {% csrf_token %}
+            {{ invite_form|as_bootstrap }}
+            <input type="submit" value="invite" />
+          </form>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block extra_script %}
+{% with "none" as layer %}
+{% include "_permissions_form_js.html" %}
+{% endwith %}
+{% endblock extra_script %}

--- a/mapstory/tests.py
+++ b/mapstory/tests.py
@@ -23,6 +23,9 @@ from geonode.geoserver.helpers import gs_catalog
 from django import db
 from .importers import GeoServerLayerCreator
 from osgeo_importer.utils import UploadError
+from geonode.groups.models import GroupProfile
+from geonode.contrib.collections.models import Collection
+from datetime import datetime
 
 User = get_user_model()
 
@@ -349,7 +352,6 @@ class MapStoryTests(MapStoryTestMixin):
         # Regardless of email content used, ensure it personally addresses the user
         self.assertTrue(user.username in mail.outbox[1].body or user.first_name in mail.outbox[1].body)
 
-
 class Oauth2ProviderTest(TestCase):
 
     fixtures = ['test_user_data.json']
@@ -492,6 +494,84 @@ class MapStoryTestsWorkFlowTests(MapStoryTestMixin):
         for lkeyword in layer.keywords.all():
             layer_keywords_names.append(lkeyword.name)
         self.assertEqual(layer_keywords_names, new_keywords_names)
+
+    def test_organizations(self):
+        admin = AdminClient()
+        admin.login_as_admin()
+        response = admin.get(reverse('organization_create'))
+        self.assertEqual(response.status_code, 200)
+        self.assertHasGoogleAnalytics(response)
+
+        # Create new organization
+        form_data = {'social_twitter': 'notreal', 'social_facebook': 'notreal', 'title': 'Test Organization',
+        'description': 'Testing', 'email': 'test@test.com', 'access': 'public', 'date_joined': datetime.now(),
+        'city': 'Victoria', 'country': 'CAN', 'keywords': 'test', 'profile_type': 'org', 'slug': 'Test-Organization'}
+        response = admin.post(reverse('organization_create'), data=form_data)
+        # Redirect when form is submitted, therefore 302
+        self.assertEqual(response.status_code, 302)
+
+        # When the organization is created, a GroupProfile and Collection model pointing to it should be created
+        group = GroupProfile.objects.all().first()
+        collection = Collection.objects.all().first()
+        self.assertEqual(collection.group, group)
+
+        # Test editing the organization
+        form_data = {'title': 'Test Organization', 'description': 'Edit', 'keywords': 'edit', 'profile_type': 'org',
+        'access': 'public', 'slug': 'Test-Organization', 'date_joined': datetime.now()}
+        response = admin.post(reverse('organization_edit', args=[group.slug]), data=form_data)
+        # Redirect when form is submitted, therefore 302
+        self.assertEqual(response.status_code, 302)
+
+        group = GroupProfile.objects.all().first()
+        self.assertEqual(group.description, 'Edit')
+        group_keywords = []
+        for keyword in group.keywords.all():
+            group_keywords.append(keyword.name)
+        self.assertEqual(group_keywords, ['edit'])
+
+        # Make sure the detail page can be viewed by a regular user
+        c = Client()
+        response = c.get(reverse('organization_detail', args=[group.slug]))
+        self.assertEqual(response.status_code, 200)
+
+    def test_initiatives(self):
+        admin = AdminClient()
+        admin.login_as_admin()
+        response = admin.get(reverse('initiative_create'))
+        self.assertEqual(response.status_code, 200)
+        self.assertHasGoogleAnalytics(response)
+
+        # Create new organization
+        form_data = {'social_twitter': 'notreal', 'social_facebook': 'notreal', 'title': 'Test Initiative',
+        'description': 'Testing', 'email': 'test@test.com', 'access': 'public', 'date_joined': datetime.now(),
+        'city': 'Victoria', 'country': 'CAN', 'keywords': 'test', 'profile_type': 'ini', 'slug': 'Test-Initiative'}
+        response = admin.post(reverse('initiative_create'), data=form_data)
+        # Redirect when form is submitted, therefore 302
+        self.assertEqual(response.status_code, 302)
+
+        # When the organization is created, a GroupProfile and Collection model pointing to it should be created
+        group = GroupProfile.objects.all().first()
+        collection = Collection.objects.all().first()
+        self.assertEqual(collection.group, group)
+
+        # Test editing the organization
+        form_data = {'title': 'Test Initiative', 'description': 'Edit', 'keywords': 'edit', 'profile_type': 'ini',
+        'access': 'public', 'slug': 'Test-Initiative', 'date_joined': datetime.now()}
+        response = admin.post(reverse('initiative_edit', args=[group.slug]), data=form_data)
+        # Redirect when form is submitted, therefore 302
+        self.assertEqual(response.status_code, 302)
+
+        group = GroupProfile.objects.all().first()
+        self.assertEqual(group.description, 'Edit')
+        group_keywords = []
+        for keyword in group.keywords.all():
+            group_keywords.append(keyword.name)
+        self.assertEqual(group_keywords, ['edit'])
+
+        # Make sure the detail page can be viewed by a regular user
+        c = Client()
+        response = c.get(reverse('initiative_detail', args=[group.slug]))
+        self.assertEqual(response.status_code, 200)
 
 
 class LayersCreateTest(MapStoryTestMixin):

--- a/mapstory/urls.py
+++ b/mapstory/urls.py
@@ -31,8 +31,10 @@ from geonode.geoserver.views import layer_acls, resolve_user, layer_batch_downlo
 from django.core.urlresolvers import reverse_lazy
 from django.views.generic import RedirectView
 from osgeo_importer.urls import urlpatterns as importer_urlpatterns
-from mapstory.views import organization_create, organization_edit, organization_detail
-from mapstory.views import initiative_create, initiative_edit, initiative_detail
+from mapstory.views import organization_create, organization_edit, organization_detail, organization_members
+from mapstory.views import organization_invite, organization_members_add, organization_member_remove
+from mapstory.views import initiative_create, initiative_edit, initiative_detail, initiative_members
+from mapstory.views import initiative_invite, initiative_members_add, initiative_member_remove
 
 # -- Deprecated url routes for Geoserver authentication -- remove after GeoNode 2.1
 # -- Use /gs/acls, gs/resolve_user/, gs/download instead
@@ -111,9 +113,18 @@ urlpatterns = patterns('',
     url(r'^organizations/create/$', organization_create, name='organization_create'),
     url(r'^organizations/(?P<slug>[^/]*)$', organization_detail, name='organization_detail'),
     url(r'^organizations/edit/(?P<slug>[^/]*)$', organization_edit, name='organization_edit'),
+    url(r'^organizations/members/(?P<slug>[^/]*)$', organization_members, name='organization_members'),
+    url(r'^organizations/invite/(?P<slug>[^/]*)$', organization_invite, name='organization_invite'),
+    url(r'^organizations/(?P<slug>[^/]*)/members_add/$', organization_members_add, name='organization_members_add'),
+    url(r'^organizations/(?P<slug>[^/]*)/member_remove/(?P<username>.+)$', organization_member_remove,
+        name='organization_member_remove'),
     url(r'^initiatives/create/$', initiative_create, name='initiative_create'),
     url(r'^initiatives/(?P<slug>[^/]*)$', initiative_detail, name='initiative_detail'),
     url(r'^initiatives/edit/(?P<slug>[^/]*)$', initiative_edit, name='initiative_edit'),
+    url(r'^initiatives/members/(?P<slug>[^/]*)$', initiative_members, name='initiative_members'),
+    url(r'^initiatives/invite/(?P<slug>[^/]*)$', initiative_invite, name='initiative_invite'),
+    url(r'^initiatives/(?P<slug>[^/]*)/members_add/$', initiative_members_add, name='initiative_members_add'),
+    url(r'^initiatives/(?P<slug>[^/]*)/member_remove/(?P<username>.+)$', initiative_member_remove, name='initiative_member_remove'),
 
     url(r'^get(?P<slug>\w+)$', GetPageView.as_view(), name='getpage'),
     url(r'^search/$', SearchView.as_view(), name='search'),


### PR DESCRIPTION
Cleaning up some minor UI issues on the org/initiative pages, as well as adding workflow tests for the pages.

Note: This can be refactored to use class based views and content mixins so that there's not these near duplicates of functional based views. This was just my first attempt by essentially copying what groups did. Everything works fine like this, but there is duplicated code.
