### PR TITLE
Fixing an error on the edit button on the explore page

### DIFF
--- a/mapstory/templates/search/_result_content.html
+++ b/mapstory/templates/search/_result_content.html
@@ -33,7 +33,7 @@
                 <!-- goes to composer -->
                 <a href="/maps/new?layer={{ item.detail_url.substring(8) | decodeURIComponent }}"><button class="btn btn-primary btn-xs"><i class="fa fa-play"></i> use</button></a>
                 <!-- goes to layer edit -->
-                <a href='{% url "map-edit" %}?layer={{resource.service_typename}}&mode=edit'><button class="btn btn-primary btn-xs"><i class="fa fa-share-alt"></i> edit</button></a>
+                <a href='/maps/edit?layer={{ item.detail_url.substring(8) | decodeURIComponent }}&mode=edit'><button class="btn btn-primary btn-xs"><i class="fa fa-share-alt"></i> edit</button></a>
                 <!-- TODO: Hook in favorites functionality -->
                 <!-- <button class="btn btn-primary btn-xs" id="favoriteLink"><i class="fa fa-heart-o"></i> favorite</button> -->
             </h4>


### PR DESCRIPTION
My previous attempt did not work, and yesterday I was unable to test layers locally but I resolved that now and this fix is working.  This PR will allow you to enter edit mode properly from the explore page on a specific layer's card.
