### PR TITLE
Remove Header Inside Composer

### DIFF
--- a/mapstory/templates/maps/_map_view_maploom.html
+++ b/mapstory/templates/maps/_map_view_maploom.html
@@ -1,43 +1,15 @@
-{% extends "site_base.html" %}
-
-{% load i18n %}
-
-{% block title %} {% trans "Explorer" %} -  {{map.title}} - {{ block.super }} {% endblock %}
-
-{% block head %}
-{{ block.super }}
 <style>
 body{
-    padding-bottom: 0px;
+    padding-bottom: 0;
     overflow: hidden;
+    margin:0;
 }
 .maploom{
     width: 100%;
-    border:0px;
+    height: 100%;
+    border:0;
+    margin:0;
+    padding:0;
 }
 </style>
-{% endblock %}
-
-{% block extra_script %}
-    <script type="text/javascript">
-      $(document).ready(function() {
-          var setHeight = function(){
-            return $('.maploom').css({height:$(window).height()-($('.navbar').height()+$('.classification-banner-text').height())});
-          }
-          $('#wrap').css({'padding-top':0});
-          $('body').css({'padding-top':$('.classification-banner-text').height()+$('.navbar').height()});
-          setHeight();
-          $(window).resize(function(){
-                  setHeight();
-                  });
-          });
-    </script>
-{% endblock %}
-
-{% block header %}{{ block.super }} {% endblock %}
-
-{% block middle %}
-        <iframe src="{% if map %}{% url 'maploom-map-view' map.id %}{% else %}{% url 'maploom-map-new' %}{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}{% endif %}" allowFullScreen="true" scrolling="auto" class="maploom"></iframe>
-{% endblock %}
-
-{% block footer %}{% endblock %}
+<iframe src="{% if map %}{% url 'maploom-map-view' map.id %}{% else %}{% url 'maploom-map-new' %}{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}{% endif %}" allowFullScreen="true" scrolling="auto" class="maploom"></iframe>


### PR DESCRIPTION
This pull request removes the header inside of Composer, now that the sidebar has it's own built in navigation.  The new navigation opens in new tabs so that the user does not lose their MapStory.  

This pull request also changes the styling that was previously on the page a bit, so that there's not a margin around the entire site.
