### PR TITLE
Show full map titles on mouse rollover

### DIFF
--- a/mapstory/static/mapstory/js/search.js
+++ b/mapstory/static/mapstory/js/search.js
@@ -182,6 +182,7 @@
     $scope.query.limit = $scope.query.limit || CLIENT_RESULTS_LIMIT;
     $scope.query.offset = $scope.query.offset || 0;
     $scope.page = Math.round(($scope.query.offset / $scope.query.limit) + 1);
+    $scope.numpages = Math.round(($scope.total_counts / $scope.query.limit) + 0.49);
 
     $scope.search = function() {
       $scope.query.limit = 100;

--- a/mapstory/templates/search/_result_content.html
+++ b/mapstory/templates/search/_result_content.html
@@ -9,11 +9,11 @@
         <div ng-if="item.type === 'mapstory'">
         <a href="/mapstory/{{ item.id }}"><img class="thumb img-responsive" ng-src="{{ item.thumbnail_url | decodeURIComponent }}"/></a>
         </div>
-        <h3 ng-if="item.type === 'layer'">
-            <a href="{{ item.detail_url}}">{{ item.title | limitTo:25}}</a>
+        <h3 ng-if="item.type === 'layer'" ng-init="truncated=true" ng-mouseover="truncated=false" ng-mouseleave="truncated=true">
+            <a href="{{ item.detail_url}}"><p ng-show="truncated">{{ item.title | limitTo:25}}</p><p ng-hide="truncated">{{ item.title }}</p></a>
         </h3>
-        <h3 ng-if="item.type === 'mapstory'">
-            <a href="/mapstory/{{ item.id }}">{{ item.title | limitTo:25}}</a>
+        <h3 ng-if="item.type === 'mapstory'" ng-init="truncated=true" ng-mouseover="truncated=false" ng-mouseleave="truncated=true">
+            <a href="/mapstory/{{ item.id }}"><p ng-show="truncated">{{ item.title | limitTo:25}}</p><p ng-hide="truncated">{{ item.title }}</p></a>
         </h3>
         <!-- item.is_published for public or not -->
         <div>


### PR DESCRIPTION
Set initial numpages value so pagination does not show NaN before loading

Addresses [Issue #1401](https://github.com/MapStory/mapstory/issues/1401)
