### PR TITLE
inline CSS to align navbar quicksearch

### DIFF
--- a/mapstory/templates/mapstory/_header.html
+++ b/mapstory/templates/mapstory/_header.html
@@ -38,7 +38,7 @@
                 </li>
                 <li class="navbar-menu">
                     <form class="navbar-form" id="search" action="{% url "search" %}">
-                        <div class="col-md-3" style="width:285px;">
+                        <div class="col-md-3" style="width:285px;margin-top: 10px;">
                           <div class="input-group">
                             {% if HAYSTACK_SEARCH %}
                             <input id="quicksearch" type="text" class="form-control" name="q">


### PR DESCRIPTION
Quick fix to center the quicksearch input vertically on the navbar div
