### PR TITLE
Save Name on Register

### DIFF
--- a/mapstory/forms.py
+++ b/mapstory/forms.py
@@ -7,6 +7,14 @@ from geonode.base.models import ResourceBase
 import taggit
 from geonode.groups.models import GroupProfile
 from geonode.groups.forms import GroupForm, GroupUpdateForm
+import account.forms
+
+
+class SignupForm(account.forms.SignupForm):
+
+    first_name = forms.CharField(label='First Name', max_length=100)
+    last_name = forms.CharField(label='Last Name', max_length=100)
+
 
 # A form for just keywords
 class KeywordsForm(forms.ModelForm):

--- a/mapstory/templates/_login_register.html
+++ b/mapstory/templates/_login_register.html
@@ -57,10 +57,10 @@
                             <div class="form-group">
                                 <label class="col-md-3 control-label label-font-sm" for="id_firstname">Name</label>
                                 <div class="col-md-4">
-                                    <input class="form-control" name="firstname" id="id_firstname" placeholder="First" type="text">
+                                    <input class="form-control" name="first_name" id="id_first_name" placeholder="First" type="text">
                                 </div>
                                 <div class="col-md-4">
-                                    <input class="form-control" id="id_lastname" name="lastname" placeholder="Last" type="text">
+                                    <input class="form-control" id="id_last_name" name="last_name" placeholder="Last" type="text">
                                 </div>
                             </div>
                             <div class="form-group">

--- a/mapstory/tests.py
+++ b/mapstory/tests.py
@@ -309,9 +309,9 @@ class MapStoryTests(MapStoryTestMixin):
         user = authenticate(**data)
         self.assertTrue(user)
         self.assertEqual(user.username, data['username'])
-        self.assertEqual(user.name_long, data['name_long'])
-        # self.assertEqual(user.first_name, data['first_name']) - TODO: These aren't saving, we need to look into this.
-        # self.assertEqual(user.last_name, data['last_name']) - TODO: These aren't saving, we need to look into this.
+        self.assertEqual(user.name_long, data['first_name'] + ' ' + data['last_name'] + ' (' + data['username'] + ')')
+        self.assertEqual(user.first_name, data['first_name'])
+        self.assertEqual(user.last_name, data['last_name'])
         self.assertEqual(user.email, data['email'])
 
         response = c.post(reverse('account_confirm_email', args=[conf.key]))

--- a/mapstory/urls.py
+++ b/mapstory/urls.py
@@ -19,6 +19,7 @@ from mapstory.views import map_detail
 from mapstory.views import layer_detail, layer_detail_id, layer_create
 from mapstory.views import layer_remove, map_remove
 from mapstory.views import MapStoryConfirmEmailView
+from mapstory.views import MapStorySignupView
 from mapstory.notifications import notify_download, set_profile_notification
 from geonode.geoserver.views import layer_acls, resolve_user, layer_batch_download
 from django.core.urlresolvers import reverse_lazy
@@ -57,6 +58,7 @@ urlpatterns = patterns('',
     url(r'^blog/comments/', include('fluent_comments.urls')),
 
     url(r'^$', IndexView.as_view(), name="index_view"),
+    url(r"^account/signup/$", MapStorySignupView.as_view(), name="account_signup"),
     url(r'^accounts/profile/$', RedirectView.as_view(url=reverse_lazy('index_view'))), #temp fix for social auth redirect
     url(r'^accounts/verify/$', 'mapstory.views.account_verify',  name='account_verify'),
     url(r"^account/confirm_email/(?P<key>\w+)/$", MapStoryConfirmEmailView.as_view(), name="account_confirm_email"),

--- a/mapstory/views.py
+++ b/mapstory/views.py
@@ -1,5 +1,6 @@
 import datetime
 from account.views import ConfirmEmailView
+from account.views import SignupView
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_POST
 from django.core.exceptions import PermissionDenied
@@ -48,6 +49,7 @@ from geonode.utils import default_map_config
 from mapstory.forms import DeactivateProfileForm, EditProfileForm
 from mapstory.forms import KeywordsForm, MetadataForm, PublishStatusForm
 from mapstory.forms import OrganizationForm, OrganizationUpdateForm
+from mapstory.forms import SignupForm
 from geonode.security.views import _perms_info_json
 from geonode.documents.models import get_related_documents
 
@@ -83,6 +85,7 @@ from django.http import HttpResponse, HttpResponseServerError
 from django.template import loader
 from health_check.plugins import plugin_dir
 
+
 class IndexView(TemplateView):
     template_name = 'index.html'
 
@@ -97,6 +100,21 @@ class IndexView(TemplateView):
         ctx['diary_entries'] = DiaryEntry.objects.filter(publish=True,show_on_main=True)[:8]
 
         return ctx
+
+
+class MapStorySignupView(SignupView):
+
+    form_class = SignupForm
+
+    def after_signup(self, form):
+        self.create_profile(form)
+        super(MapStorySignupView, self).after_signup(form)
+
+    def create_profile(self, form):
+        profile = self.created_user
+        profile.first_name = form.cleaned_data["first_name"]
+        profile.last_name = form.cleaned_data["last_name"]
+        profile.save()
 
 
 class DiaryListView(ListView):


### PR DESCRIPTION
Saving the user's first and last name when they register, adding back in the tests for first and last name and fixing the test for name_long based on what the code written for it is expecting.