### PR TITLE
Allow admins to edit all thumbs; move thumbs to module

### DIFF
--- a/mapstory/apps/thumbnails/models.py
+++ b/mapstory/apps/thumbnails/models.py
@@ -1,0 +1,42 @@
+from PIL import Image
+from django.db import models
+import os
+from django.conf import settings
+from django import forms
+from solo.models import SingletonModel
+from resizeimage import resizeimage
+from io import BytesIO
+from django.core.files.base import ContentFile
+
+class ThumbnailImage(SingletonModel):
+    thumbnail_image = models.ImageField(
+        upload_to=os.path.join(settings.MEDIA_ROOT, 'thumbs'),
+    )
+
+    def save(self, *args, **kwargs):
+        pil_image_obj = Image.open(self.thumbnail_image)
+        new_image = resizeimage.resize_cover(
+            pil_image_obj,
+            [250, 150],
+            validate=False
+        )
+
+        new_image_io = BytesIO()
+        new_image.save(new_image_io, format='PNG')
+
+        temp_name = self.thumbnail_image.name
+        self.thumbnail_image.delete(save=False)
+
+        self.thumbnail_image.save(
+            temp_name,
+            content=ContentFile(new_image_io.getvalue()),
+            save=False
+        )
+
+        super(ThumbnailImage, self).save(*args, **kwargs)
+
+
+class ThumbnailImageForm(forms.Form):
+    thumbnail_image = forms.FileField(
+        label='Select a file',
+    )

--- a/mapstory/apps/thumbnails/tests.py
+++ b/mapstory/apps/thumbnails/tests.py
@@ -1,0 +1,34 @@
+from django.test import TestCase, Client
+from unittest import skip
+
+from .models import ThumbnailImage, ThumbnailImageForm
+
+class TestThumbnailImage(TestCase):
+    """
+    Thumbnail Image model tests
+    """
+    def setUp(self):
+        self.thumbnailImage = ThumbnailImage()
+        self.assertIsInstance(self.thumbnailImage, ThumbnailImage)
+
+    def test_unicode(self):
+        self.assertIsNotNone(unicode(self.thumbnailImage))
+
+    @skip("TODO")
+    def test_save_and_retrieve(self):
+        pass
+
+class TestThumbnailImageForm(TestCase):
+    """
+    ThumbnailImageForm model tests
+    """
+    def setUp(self):
+        self.tif = ThumbnailImageForm()
+        self.assertIsInstance(self.tif, ThumbnailImageForm)
+
+    def test_unicode(self):
+        self.assertIsNotNone(unicode(self.tif))
+
+    @skip("TODO")
+    def test_save_and_retrieve(self):
+        pass

--- a/mapstory/models.py
+++ b/mapstory/models.py
@@ -17,12 +17,7 @@ from geonode.maps.models import Map
 from geonode.people.models import profile_post_save
 from guardian.shortcuts import get_objects_for_user
 from django.contrib.sites.models import Site
-from PIL import Image
 from django import forms
-from solo.models import SingletonModel
-from resizeimage import resizeimage
-from django.core.files.base import ContentFile
-from io import BytesIO
 from journal.models import JournalEntry
 
 from mapstory.notifications import set_mapstory_notifications
@@ -198,41 +193,6 @@ class ParallaxImage(models.Model):
 
     def __unicode__(self):
         return self.image.url
-
-
-class ThumbnailImage(SingletonModel):
-    thumbnail_image = models.ImageField(
-        upload_to=os.path.join(settings.MEDIA_ROOT, 'thumbs'),
-    )
-
-    def save(self, *args, **kwargs):
-        pil_image_obj = Image.open(self.thumbnail_image)
-        new_image = resizeimage.resize_cover(
-            pil_image_obj,
-            [250, 150],
-            validate=False
-        )
-
-        new_image_io = BytesIO()
-        new_image.save(new_image_io, format='PNG')
-
-        temp_name = self.thumbnail_image.name
-        self.thumbnail_image.delete(save=False)
-
-        self.thumbnail_image.save(
-            temp_name,
-            content=ContentFile(new_image_io.getvalue()),
-            save=False
-        )
-
-        super(ThumbnailImage, self).save(*args, **kwargs)
-
-
-class ThumbnailImageForm(forms.Form):
-    thumbnail_image = forms.FileField(
-        label='Select a file',
-    )
-
 
 def get_images():
     return ParallaxImage.objects.all()

--- a/mapstory/templates/layers/_details.html
+++ b/mapstory/templates/layers/_details.html
@@ -99,6 +99,7 @@
                                         </tr>
                                         {% if content_moderators in user.groups.all or user == resource.owner %}
                                         <tr>                                            
+                                        {% if content_moderators in user.groups.all or user == resource.owner or user.is_superuser %}
                                             <td width="35%">Thumbnail</td>
                                             <td width="35%">
                                                 <a href="{{ thumbnail }}"><img ng-src="{{ thumbnail }}" src="{{ thumbnail }}" id="change-thumbnail-image"></a>

--- a/mapstory/templates/maps/_story_details.html
+++ b/mapstory/templates/maps/_story_details.html
@@ -207,17 +207,46 @@
                                     </div>
                                 </div>
                                 {% endfor %}
-                            </div>    
+                            </div>
                         </div>
                     </div>
+                    {% if content_moderators in user.groups.all or user == resource.owner or user.is_superuser %}
+                    <div class="Summary">
+                      <div>
+                        <h3>
+                          Thumbnail
+                        </h3>
+                      </div>
+                      <hr>
+                      <tr>
+                          <td width="35%">
+                              <a href="{{ thumbnail }}"><img ng-src="{{ thumbnail }}" src="{{ thumbnail }}" id="change-thumbnail-image"></a>
+
+                              <form action="" method="post" enctype="multipart/form-data">
+                            {% csrf_token %}
+                            <p>{{ thumb_form.non_field_errors }}</p>
+                            <p>{{ thumb_form.docfile.label_tag }} </p>
+                            <p>
+                                {{ thumb_form.thumbnail_image.errors }}
+                                {{ thumb_form.thumbnail_image }}
+                            </p>
+                            <button style="width:200px" class="btn btn-primary btn-md btn-block" type="submit">
+                              Change Image
+                            </button>
+                        </form>
+                          </td>
+                      </tr>
+                    </div>
+                    {% endif %}
                     {% if resource.owner == user %}
                     <div style= "padding-top: 40px">
                         <button class="btn btn-danger">
-                            <a href="{% url "map_remove" resource.id %}">{% trans "Delete this " %}{{SITE_NAME}}</a> 
+                            <a href="{% url "map_remove" resource.id %}">{% trans "Delete this " %}{{SITE_NAME}}</a>
                         </button>
                     </div>
                     {% endif %}
                 </div>
+
             </div>
         </div>
     </section>

--- a/mapstory/test.py
+++ b/mapstory/test.py
@@ -20,4 +20,4 @@ from tests.testMapstory import *
 from journal.tests import *
 from apps.boxes.tests import *
 from apps.flag.tests import *
-
+from apps.thumbnails.tests import *

--- a/mapstory/tests/testModels.py
+++ b/mapstory/tests/testModels.py
@@ -421,33 +421,3 @@ class TestParallaxImage(TestCase):
     @skip("TODO")
     def test_save_and_retrieve(self):
         pass
-
-class TestThumbnailImage(TestCase):
-    """
-    Thumbnail Image model tests
-    """
-    def setUp(self):
-        self.thumbnailImage = ThumbnailImage()
-        self.assertIsInstance(self.thumbnailImage, ThumbnailImage)
-
-    def test_unicode(self):
-        self.assertIsNotNone(unicode(self.thumbnailImage))
-
-    @skip("TODO")
-    def test_save_and_retrieve(self):
-        pass
-
-class TestThumbnailImageForm(TestCase):
-    """
-    ThumbnailImageForm model tests
-    """
-    def setUp(self):
-        self.tif = ThumbnailImageForm()
-        self.assertIsInstance(self.tif, ThumbnailImageForm)
-
-    def test_unicode(self):
-        self.assertIsNotNone(unicode(self.tif))
-
-    @skip("TODO")
-    def test_save_and_retrieve(self):
-        pass

--- a/mapstory/views.py
+++ b/mapstory/views.py
@@ -30,7 +30,7 @@ from mapstory.models import GetPage
 from mapstory.models import NewsItem
 from journal.models import JournalEntry
 from mapstory.models import Leader
-from mapstory.models import ThumbnailImage, ThumbnailImageForm
+from mapstory.apps.thumbnails.models import ThumbnailImage, ThumbnailImageForm
 from icon_commons.models import Icon
 from geonode.contrib.favorite.models import Favorite
 from geonode.contrib.collections.models import Collection


### PR DESCRIPTION
This PR:
- Allows admins to edit thumbnails for all layers and mapstories 
- Moves the thumbnail models and tests into a separate module
- Adds a thumbnail form to the story detail template