### PR TITLE
Update the location of osgeo-importer in our requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 -e git://github.com/pinax/django-mailer.git#egg=django-mailer
 -e git://github.com/MapStory/icon-commons.git#egg=icon-commons
--e git://github.com/ProminentEdge/django-osgeo-importer.git@mapstory-wip#egg=osgeo_importer
+-e git://github.com/GeoNode/django-osgeo-importer.git@mapstory-wip#egg=osgeo_importer
 
 docutils
 textile


### PR DESCRIPTION
Update the location of osgeo-importer in our requirements.txt as it has moved to the GeoNode organization on Github.