### PR TITLE
Bug/force lowercase

### DIFF
--- a/mapstory/templates/_login_register.html
+++ b/mapstory/templates/_login_register.html
@@ -18,7 +18,7 @@
                             <div class="form-group">
                                 <label class="col-md-3 control-label label-font-sm" for="username">Username</label>
                                 <div class="col-md-8">
-                                    <input class="form-control" name="username" id="username" placeholder="username" type="text">
+                                    <input class="form-control" style="text-transform: lowercase;" name="username" id="username" placeholder="username" type="text">
                                 </div>
                             </div>
                             <div class="form-group">
@@ -50,7 +50,7 @@
                             <div class="form-group">
                                 <label class="col-md-3 control-label label-font-sm" for="id_username">Username</label>
                                 <div class="col-md-8">
-                                    <input class="form-control" name="username" id="id_username" placeholder="username" type="text">
+                                    <input class="form-control" style="text-transform: lowercase;" name="username" id="id_username" placeholder="username" type="text">
                                 </div>
                             </div>
                             <div class="form-group">

--- a/mapstory/views.py
+++ b/mapstory/views.py
@@ -705,7 +705,7 @@ def layer_create(request, template='upload/layer_create.html'):
         if configuration_options['featureType'].get('editable') is True:
             configuration_options['storeCreateGeogig'] = True
 
-        store_name = '{0}-layers'.format(request.user.username)
+        store_name = '{0}-layers'.format(request.user.username.lower())
         configuration_options['featureType']['store']['name'] = store_name;
 
         creator = GeoServerLayerCreator()


### PR DESCRIPTION
Prevent users from registering or logging in with mixed cased usernames and also makes sure the create_layer function lowers the case of the username when build the store name string.