### PR TITLE
Tweak styles of viewer sidebar to so chapter navigation doesn't require scroll

### DIFF
--- a/mapstory/static/style/maps/viewer.less
+++ b/mapstory/static/style/maps/viewer.less
@@ -19,6 +19,9 @@ html, body {
   overflow: scroll;
   z-index: 2;
   opacity: .9;
+  .content {
+    padding: 10px;
+  }
 }
 
 .sidebarHidden {
@@ -30,39 +33,57 @@ html, body {
   margin: 0;
   color: @gray40;
   left: -17.25%;
-  z-index: 2
+  z-index: 2;
 }
 
 .sidebar p {
   font-size: 12px;
   padding: 6px 0;
-  max-height: 45vh;
+  max-height: 30vh;
   overflow-y: scroll;
+  line-height: 1.5;
+  font-weight: 500;
 }
 
-.sidebar a {
-  color: @gray55;
-  display: block;
-  font-size: 12px;
-  font-weight: 700;
-  line-height: 20px;
-  outline: 0;
-  overflow: hidden;
-  text-decoration: none;
-}
-
-.sidebar i {
+.viewer-nav i {
   color: @gray97;
   float: right;
   font-size: 15px;
-  padding: 3px 10px 0;
+  margin: 10px;
+  cursor: pointer;
+  &.fa-caret-right {
+    display: none;
+  }
 }
 
 .sidebarHidden i {
   color: @gray97;
   float: right;
   font-size: 15px;
-  padding: 3px 10px 0;
+  margin: 10px;
+  &.fa-caret-left {
+    display: none;
+  }
+  &.fa-caret-right {
+    cursor: pointer;
+    display: block;
+  }
+}
+
+.viewer-chapter-nav {
+  font-size: 13px;
+  a {
+    color: @link-color;
+    float: left;
+    clear: both;
+    margin-bottom: 5px;
+    &:hover, &:active {
+      color: @link-color-hover;
+    }
+    &[disabled] {
+      display: none;
+    }
+  }
 }
 
 .st-legend {
@@ -93,51 +114,50 @@ html, body {
 
 }
 
-.viewerTopNav {
+.viewer-nav {
   background: @primary;
   height: 40px;
   padding: 3px;
 }
 
-.viewerTopNav a {
+.viewer-nav a {
   display: inline;
 }
 
-.topText {
-  color: @gray55;
+.viewer-author {
+  color: @link-color;
   display: block;
   font-size: 10px;
-  font-weight: 700;
+  font-weight: 600;
   line-height: 10px;
   margin: 0;
-  padding: 5px 10px;
+  padding: 5px 0; 
+  &:hover, &:active {
+    color: @link-color-hover;
+  }
 }
 
-.bottomText {
-  color: @gray55;
+.viewer-story-title {
+  color: @gray20;
   display: block;
-  font-size: 18px;
+  font-size: 15px;
   font-weight: 700;
-  line-height: 24px;
-  margin: 0;
-  padding: 10px 10px 0px;
-}
-
-.menuItem {
-  padding: 10px;
-  margin: 10px;
-  background: @gray90;
-  border-radius: 4px;
-}
-
-.menuItem h5 {
+  line-height: 1.5;
   margin: 0;
 }
 
-.menuItem h3 {
-  font-size: 13px;
-  font-weight: 700;
-  line-height: 20px;
+.viewer-chapter-number {
+	margin: 10px 0 0;
+  text-transform: uppercase;
+  font-size: 10px;
+  font-weight: 600;
+  color: @gray55;
+}
+
+.viewer-chapter-title {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.3;
   margin: 0;
 }
 

--- a/mapstory/static/style/site/variables.less
+++ b/mapstory/static/style/site/variables.less
@@ -7,9 +7,12 @@
 // Medium devices (desktops, 992px and up)
 @desktops: ~"only screen and (min-width: 992px)";
 
+@link-color: #de5c0d;
+@link-color-hover: #ff6c13;
+
 @bs-blue: #428bca;
-@facebook: #1E90FF;
-@google: #162F43;
+@facebook: #1e90ff;
+@google: #162f43;
 
 @black: #000;
 @white: #fff;

--- a/mapstory/templates/viewer/story_viewer.html
+++ b/mapstory/templates/viewer/story_viewer.html
@@ -13,50 +13,42 @@
 {% endblock head %}
 
 {% block middle %}
-<div ng-app="viewer" ng-controller="viewerController as viewer" id="story-viewer">
+<div ng-app="viewer" ng-controller="viewerController as viewer">
     <div class="st-legend"></div>
     <div class="sidebar" id="sidebar">
-        <div class="viewerTopNav">
+        <div class="viewer-nav">
             <a target="_blank" href="{% url "home" %}">
-            {% if site.assets.favicon %}
-                <img src="/uploaded/{{ site.assets.favicon.name }}" id="sidebarDropdown" width="35px" height="35px"/>
-                {% comment %}<img src="https://res.cloudinary.com/dw1zyrzc5/image/upload/v1461606100/ms_logo_white_pot8b9.png" id="sidebarDropdown" width="35px" height="35px"/>{% endcomment %}
-            {% else %}
-                <i class="fa fa-home pull-left" id="sidebarDropdown"></i>
-            {% endif %}   
+                {% if site.assets.favicon %}
+                    <img src="/uploaded/{{ site.assets.favicon.name }}" width="35px" height="35px"/>
+                    {% comment %}<img src="https://res.cloudinary.com/dw1zyrzc5/image/upload/v1461606100/ms_logo_white_pot8b9.png" id="sidebarDropdown" width="35px" height="35px"/>{% endcomment %}
+                {% else %}
+                    <i class="fa fa-home pull-left"></i>
+                {% endif %}
             </a>
-            <i class="fa fa-bars" ng-click="toggleSidebar()"></i>
+            <i class="fa fa-caret-left" ng-click="toggleSidebar()"></i>
+            <i class="fa fa-caret-right" ng-click="toggleSidebar()"></i>
         </div>
-        <div id="content">
+        <div class="content">
             {% verbatim %}
-            <div id="title">
-                <a target="_blank" href="/story/{{ mapManager.storyMap.get('id') - 1 }}/view">
-                    <div class="bottomText" ng-bind="mapManager.title"></div>
+            <a target="_blank" href="/story/{{ mapManager.storyMap.get('id') - 1 }}/view" class="viewer-story-title" ng-bind="mapManager.title"></a>
+            {% endverbatim %}
+            <a target="_blank" href="/storyteller/{{ mapManager.username }}" class="viewer-author">{{ SITE_NAME }} {% verbatim %}by {{ mapManager.owner }}</a>
+            <div class="viewer-chapter-number">Chapter {{ mapManager.storyChapter}}</div>
+            <div class="viewer-chapter-title" ng-bind="mapManager.storyMap.getStoryTitle()"></div>
+            <p ng-bind="mapManager.storyMap.getStoryAbstract()"></p>
+            {% endverbatim %}
+
+            <div ng-if="mapManager.chapterCount > 1" class="viewer-chapter-nav">
+                <a class="pointer" ng-click="previousChapter()" ng-disabled="mapManager.storyChapter == 1">
+                    <i class="fa fa-step-backward"></i>
+                    Previous Chapter
                 </a>
-            </div>
-            <div id="author">
-                <a target="_blank" href="/storyteller/{{ mapManager.username }}">
-                {% endverbatim %}
-                    <div class="topText">{{ SITE_NAME }} {% verbatim %}by {{ mapManager.owner }}</div>
+                <a class="pointer" ng-click="nextChapter()" ng-disabled="mapManager.storyChapter == mapManager.chapterCount">
+                    Next Chapter
+                    <i class="fa fa-step-forward"></i>
                 </a>
-            </div>
-            <div id="summary" class="menuItem">
-                <h5>Chapter {{ mapManager.storyChapter }}</h5>
-                <h3 ng-bind="mapManager.storyMap.getStoryTitle()"></h3>
-                <p ng-bind="mapManager.storyMap.getStoryAbstract()"></p>
-            </div>
-            <div class="floating-below" ng-if="mapManager.chapterCount > 1">
-                <div class="menuItem">
-                    <i class="fa fa-step-backward pull-right"></i>
-                    <a class="pointer" ng-click="previousChapter()" ng-disabled="mapManager.storyChapter == 1">Previous Chapter</a>
-                </div>
-                <div class="menuItem">
-                    <i class="fa fa-step-forward pull-right"></i>
-                    <a class="pointer" ng-click="nextChapter()" ng-disabled="mapManager.storyChapter == mapManager.chapterCount">Next Chapter</a>
-                </div>
             </div>
         </div>
-        {% endverbatim %}
     </div>
     <div class="map" id="mapContainer">
         <div id="map"></div>


### PR DESCRIPTION
In my local environment:
![screen shot 2017-02-08 at 4 22 54 pm](https://cloud.githubusercontent.com/assets/1529366/22760177/ef73d076-ee1a-11e6-9b21-a875a7e9714b.png)
Sidebar open

![screen shot 2017-02-08 at 4 02 04 pm](https://cloud.githubusercontent.com/assets/1529366/22759711/14ccd4a0-ee19-11e6-8e44-df74f5ee85c0.png)
Sidebar closed

As you can see in addition to updating the styles, I made a few other tweaks:
* changed the "collapse sidebar" icon to something more intuitive, and it changes direction depending on state
* added `display: none;` to any disabled links in `.viewer-chapter-nav` so that if there isn't a next or previous chapter, no link displays

@emilyashley If you can take a close look at https://github.com/MapStory/mapstory/compare/master...412-chapter-buttons#diff-c360bb628b08d19110db7c511726e5f0, I stripped out a lot of unnecessary IDs. As far as I can tell from searching, none of them were being used for anything, and in general, [it's best practice in CSS not to use IDs since they introduce unnecessary specificity](http://oli.jp/2011/ids/). But it never hurts to have an extra pair of 👀 

One other issue I ran into locally that stumped me: the next and previous buttons for navigating between chapters don't work locally for me, despite the fact that I've created multiple chapters for the story I tested with. This was an issue locally for me even on master, so I don't think it's anything with my code, but it's yet another reason for you to give this a good once-over! ✨ 