### PR TITLE
Close pin overlay when pin disappears from map.

### DIFF
--- a/mapstory/templates/viewer/ol3-popup.js
+++ b/mapstory/templates/viewer/ol3-popup.js
@@ -27,6 +27,9 @@
         this.container.className = 'ol-popup';
         this.container.id = (options.hasOwnProperty('id')) ? options.id : '';
 
+        /*
+          Disable closer for viewer until the issue of the overlay repeatedly
+          opening during playback in resolved
 
         this.closer = document.createElement('a');
         this.closer.className = 'ol-popup-closer';
@@ -39,6 +42,7 @@
             that.closer.blur();
             evt.preventDefault();
         }, false);
+        */
 
         this.content = document.createElement('div');
         this.content.className = 'ol-popup-content';

--- a/mapstory/templates/viewer/story_viewer.js
+++ b/mapstory/templates/viewer/story_viewer.js
@@ -116,6 +116,17 @@
             }
         };
 
+        this.hidePinOverlay = function(pin) {
+          var overlays = self.storyMap.getMap().getOverlays().getArray();
+          for (var iOverlay = 0; iOverlay < overlays.length; iOverlay += 1) {
+              var overlay = overlays[iOverlay];
+              if (overlay.getId() == 'popup-' + pin.id) {
+                var map = self.storyMap.getMap();
+                map.removeOverlay(overlay);
+              }
+          }
+        };
+
         this.loadMap = function(options) {
             options = options || {};
             if (options.id) {
@@ -166,9 +177,13 @@
 
         self.loadConfig(config, chapter);
     });
-        $rootScope.$on('showPin', function(event, pin) {
-            self.displayPinInfo(null, pin);
-        });
+    $rootScope.$on('showPin', function(event, pin) {
+        self.displayPinInfo(null, pin);
+    });
+
+    $rootScope.$on('hidePinOverlay', function(event, pin) {
+        self.hidePinOverlay(pin);
+    });
 }
 
 /* EXACTLY THE SAME AS LAYER VIEWER */


### PR DESCRIPTION
***This PR relies on: https://github.com/MapStory/story-tools/pull/255***

https://github.com/MapStory/story-tools/pull/255 adds a "hidePinOverlay" emitter. 

The emitter gets used in this PR to close any overlays belonging to pins that have disappeared from the map.

This PR also removes the "X" closer from the overlay, which can be added back after the issue of the overlay repeatedly opening after a user closes it is resolved. This resolves https://github.com/MapStory/mapstory/issues/434