### PR TITLE
Redirect Delete Message Routes

### DIFF
--- a/mapstory/urls.py
+++ b/mapstory/urls.py
@@ -18,6 +18,7 @@ from mapstory.views import layer_remove, map_remove
 from mapstory.views import download_append_csv, download_append_shp
 from mapstory.views import MapStoryConfirmEmailView
 from mapstory.views import MapStorySignupView
+from mapstory.views import messages_redirect
 from mapstory.notifications import notify_download, set_profile_notification
 from geonode.geoserver.views import layer_acls, resolve_user, layer_batch_download
 from django.core.urlresolvers import reverse_lazy
@@ -52,7 +53,7 @@ layer_detail_patterns = patterns('',
     )
 
 urlpatterns = patterns('',
-
+    url(r'^messages/inbox/', messages_redirect),
     url(r'^ht/', health_check, name="health_check"),
     # Adding Threaded Comments app
     url(r'^articles/comments/', include('django_comments.urls')),

--- a/mapstory/views.py
+++ b/mapstory/views.py
@@ -1322,6 +1322,11 @@ def account_verify(request):
     return HttpResponse('{"id":"%s","first_name":"%s","last_name":"%s","username":"%s","email":"%s"}'
             % (user.id, user.first_name, user.last_name, user.username, user.email), mimetype='application/json')
 
+
 def layer_detail_id(request, layerid):
     layer = get_object_or_404(Layer, pk=layerid)    
     return layer_detail(request, layer.typename)
+
+
+def messages_redirect(request):
+    return HttpResponseRedirect("/storyteller/{}/#messages_list".format(request.user))


### PR DESCRIPTION
This resolves Github issue #338, when you delete a message you’ll now be brought back to your profile page on the messages tab.