### PR TITLE
Update fullname for commit history

### DIFF
--- a/mapstory/templates/layers/_geogig_layer_detail.html
+++ b/mapstory/templates/layers/_geogig_layer_detail.html
@@ -26,9 +26,10 @@
           <span class="label label-primary pull-right">{{ commit.id | limitTo: 10 }}</span> 
           <div class="commit-message">{{ commit.message }}</div>
           <div class="commit-byline">
-            <a ng-href="/storyteller/{{ commit.committer.name }}" target="_blank">
-                <span class="commit-author">{{commit.committer.name || 'Unknown'}}</span>
+            <a ng-href="/storyteller/{{ commit.author.name }}" target="_blank">
+                <span class="commit-author">{{commit.author.name || 'Unknown'}}</span>
                 <span class="commit-timestamp">{{ commit.commitTimeSince }}</span>
+                <span>{{ commit }}</span>
               </a>
           </div>
         </div>

--- a/mapstory/urls.py
+++ b/mapstory/urls.py
@@ -29,6 +29,7 @@ from mapstory.views import organization_create, organization_edit, organization_
 from mapstory.views import organization_invite, organization_members_add, organization_member_remove
 from mapstory.views import initiative_create, initiative_edit, initiative_detail, initiative_members
 from mapstory.views import initiative_invite, initiative_members_add, initiative_member_remove
+from mapstory.views import layer_acls_mapstory, resolve_user_mapstory
 from tastypie.api import Api
 from mapstory.api import UploadedLayerResource
 from annotations.urls import urlpatterns as annotations_urls
@@ -125,6 +126,8 @@ urlpatterns = patterns('',
     url(r'^layers/notify-download$', notify_download, name='notify-layer-download'),
     url(r'^layers/download-append-csv$', download_append_csv, name='download_append_csv'),
     url(r'^layers/download-append-shp$', download_append_shp, name='download_append_shp'),
+    url(r'^layers/acls', layer_acls_mapstory, name='layer_acls_mapstory'),
+    url(r'^layers/resolve_user', resolve_user_mapstory, name='resolve_user_mapstory'),
 
 ) + geonode_layers_urlpatterns + layer_detail_patterns + urlpatterns
 

--- a/mapstory/views.py
+++ b/mapstory/views.py
@@ -26,6 +26,7 @@ from geonode.layers.models import Layer
 from geonode.layers.views import _resolve_layer
 from geonode.layers.views import _PERMISSION_MSG_GENERIC, _PERMISSION_MSG_VIEW, _PERMISSION_MSG_DELETE
 from geonode.people.models import Profile
+from geonode.geoserver.views import layer_acls, resolve_user
 from geonode.maps.views import snapshot_config, _PERMISSION_MSG_SAVE
 from geonode.maps.models import Map, MapStory
 from httplib import HTTPConnection, HTTPSConnection
@@ -1330,3 +1331,19 @@ def layer_detail_id(request, layerid):
 
 def messages_redirect(request):
     return HttpResponseRedirect("/storyteller/{}/#messages_list".format(request.user))
+
+
+def layer_acls_mapstory(request):
+    response = layer_acls(request)
+    result = json.loads(response.content)
+    result["fullname"] = request.user.username
+
+    return HttpResponse(json.dumps(result), content_type="application/json")
+
+
+def resolve_user_mapstory(request):
+    response = resolve_user(request)
+    result = json.loads(response.content)
+    result["fullname"] = request.user.username
+
+    return HttpResponse(json.dumps(result), content_type="application/json")


### PR DESCRIPTION
This commit resolves issues #446 and #447 on Github.  I’ve changed the fullname variable that we return to the /layers/acls and /layers/resolve_user API endpoints because geoserver-geonode extension uses the fullname rather than the username of a user.  This data then gets passed from geoserver-geonode-ext to geoserver to geogig.  This allows us to use the django username of the user for all commit related information.