### PR TITLE
Remove hardcoded subtitle in favor of django admin

### DIFF
--- a/mapstory/templates/index.html
+++ b/mapstory/templates/index.html
@@ -9,7 +9,7 @@
     </section>
     <section class="slice welcome">
         <div class="container">
-            <h1> The atlas of change anyone can edit {{ site.assets.subtitle }} </h1>
+            <h1> {{ site.assets.subtitle }} </h1>
             <div class="row search">
                 <form class="col-sm-6 col-sm-offset-3" action="{% url 'search' %}">
                     <div class="input-group homepage-search">


### PR DESCRIPTION
Removes the hard coded subtitle so that it can be added on a per deployment basis in the django admin.