### PR TITLE
Added Travis build badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 mapstory
 ================
 
-[![Coverage Status](https://coveralls.io/repos/github/MapStory/mapstory/badge.svg?branch=master)](https://coveralls.io/github/MapStory/mapstory?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/MapStory/mapstory/badge.svg?branch=master)](https://coveralls.io/github/MapStory/mapstory?branch=master) [![Build Status](https://travis-ci.org/MapStory/mapstory.svg?branch=master)](https://travis-ci.org/MapStory/mapstory)
 
 Please visit [our wiki](https://github.com/MapStory/mapstory/wiki)
 


### PR DESCRIPTION
Added a 'build' badge to the README.md to quickly communicate the build status of the master branch