### PR TITLE
Fix nav height bug (fixes #514)

### DIFF
--- a/mapstory/static/style/site/navbar-footer.less
+++ b/mapstory/static/style/site/navbar-footer.less
@@ -1,95 +1,122 @@
-nav.header {
-    button.menu {
+.navbar-header {
+    .navbar-toggle {
         text-transform: uppercase;
         float: right;
-        margin: 16px 0;
         font-size: 0.9em;
-        background-color: @gray90;
-        border: 1px solid @gray80;
-        border-radius: 3px;
+        margin: 13px;
     }
+}
+
+.navbar-collapse {
+    max-height: none !important;
 }
 
 
 /*--- NavBar ---*/
 
 .navbar-logo {
-  width: 195px;	
-  @media only screen and (max-width: 768px) {
-    // For small screens when nav	changes to collapsed hamburger menu
-    margin: 0 20px;
-  }
+    width: 195px;
+    @media only screen and (max-width: 768px) {
+        // For small screens when nav changes to collapsed hamburger menu
+        margin: 0 20px;
+    }
 }
 
 .navbar-brand {
-  background-size: 100%;
-  width: 196px;
-  margin: 10px 10px 0;
-  text-indent: -9999em;
+    background-size: 100%;
+    width: 196px;
+    margin: 10px 10px 0;
+    text-indent: -9999em;
 }
 
 .beta-tag {
-  text-transform: uppercase;
-  font-family: "Lato", Helvetica, sans-serif;
-  clear: both;
-  color: #999;
-  font-size: 10px;
-  float: right;
-  margin: -23px 30px;
-  @media only screen and (max-width: 768px) {
-    // For small screens when nav	changes to collapsed hamburger menu
-    margin: -23px 5px;
-  }
+    text-transform: uppercase;
+    font-family: "Lato", Helvetica, sans-serif;
+    clear: both;
+    color: #999;
+    font-size: 10px;
+    float: right;
+    margin: -23px 30px;
+    @media only screen and (max-width: 768px) {
+        // For small screens when nav changes to collapsed hamburger menu
+        margin: -23px 5px;
+    }
 }
 
 .navbar-nav > li > a {
-  font-weight: 500;
-  padding-top: 25px;
-  cursor: pointer;
-  @media @tablets {
-    color: red !important;
-  }
+    font-weight: 500;
+    padding-top: 25px;
+    cursor: pointer;
+    @media @tablets {
+        font-size: 0.85em;
+    }
+    @media @desktops {
+        font-size: 0.9em;
+    }
+    @media only screen and (min-width: 1200px) {
+        font-size: 1em;
+    }
 }
 
 .navbar .search {
-  width: 285px;
-  margin-top: 10px;
+    width: 220px;
+    margin-left: -15px;
+    margin-top: 10px;
+    @media only screen and (min-width: 1200px) {
+        width: 285px;
+    }
 }
 
 .dropdown-menu {
-  border-radius: 4px;
-  border: none;
-  padding: 8px 15px;
+    border-radius: 4px;
+    border: none;
+    padding: 8px 15px;
 }
 
 .nav-icon {
-  font-size: 1.3em;
+    font-size: 1.3em;
 }
 
 .nav-avatar {
-  margin: -8px -10px;
+    margin: -8px -10px;
+    @media only screen and (max-width: 768px) {
+        display: none !important;
+    }
+    @media @tablets, @desktops {
+        margin-left: 25px;
+        margin-right: -10px;
+    }
 }
 
 #createDropdown {
-  display: none;
-
-  @media @tablets, @desktops {
-    display: block;
-  }
-
+    display: none;
+    @media @tablets, @desktops {
+        display: block;
+    }
 }
 
 .quicksearchcontainer {
-  display: none;
-
-  @media @desktops {
-    display: block;
-  }
-
+    display: none;
+    @media @desktops {
+        display: block;
+        width: 200px;
+        input[type='text'] {
+            width: 190px;
+        }
+        .input-group-btn {
+            width: 20%;
+        }
+    }
+    @media only screen and (min-width: 1200px) {
+        width: 290px;
+        input[type='text'] {
+            width: 230px !important;
+        }
+    }
 }
 
 .quicksearchcontainer .fa-search{
-  padding: 3px 0;
+    padding: 3px 0;
 }
 
 #logout_form {
@@ -100,18 +127,18 @@ nav.header {
 /*--- Footer ---*/
 
 footer {
-  color: @gray55;
-  background: @primary;
-  border-top: 1px solid @gray40;
-  padding: 20px 10px;
-  width: 100%;
+    color: @gray55;
+    background: @primary;
+    border-top: 1px solid @gray40;
+    padding: 20px 10px;
+    width: 100%;
 }
 
 .footerWidget {
-  color: @white;
+    color: @white;
 }
 
 select .lang {
-  background-color: transparent;
-  color: @white;
+    background-color: transparent;
+    color: @white;
 }

--- a/mapstory/static/style/site/navbar-footer.less
+++ b/mapstory/static/style/site/navbar-footer.less
@@ -1,3 +1,16 @@
+nav.header {
+    button.menu {
+        text-transform: uppercase;
+        float: right;
+        margin: 16px 0;
+        font-size: 0.9em;
+        background-color: @gray90;
+        border: 1px solid @gray80;
+        border-radius: 3px;
+    }
+}
+
+
 /*--- NavBar ---*/
 
 .navbar-logo {
@@ -33,6 +46,9 @@
   font-weight: 500;
   padding-top: 25px;
   cursor: pointer;
+  @media @tablets {
+    color: red !important;
+  }
 }
 
 .navbar .search {

--- a/mapstory/templates/_header.html
+++ b/mapstory/templates/_header.html
@@ -1,8 +1,8 @@
 {% load i18n avatar_tags %}
 <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="container">
-        <nav class="header">
-            <button type="button" class="menu collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false"
+        <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false"
                     aria-controls="navbar">
                 <span class="sr-only">Toggle navigation</span>
                 Menu
@@ -17,7 +17,7 @@
                     {% endif %}
                 </div>
             {% endif %}
-        </nav>
+        </div>
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">
                 {% if user.is_authenticated %}

--- a/mapstory/templates/_header.html
+++ b/mapstory/templates/_header.html
@@ -1,13 +1,11 @@
 {% load i18n avatar_tags %}
 <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="container">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false"
+        <nav class="header">
+            <button type="button" class="menu collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false"
                     aria-controls="navbar">
                 <span class="sr-only">Toggle navigation</span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
+                Menu
             </button>
             {% if site.assets.logo %}
                 <div class="navbar-logo">
@@ -19,7 +17,7 @@
                     {% endif %}
                 </div>
             {% endif %}
-        </div>
+        </nav>
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">
                 {% if user.is_authenticated %}


### PR DESCRIPTION
This PR applies some quick and dirty band-aids to fix the nav height bug (#514) without addressing the underlying problems and code smells in the way our nav is written, which is to say that the code I've added breaks some of our [CSS style guidelines](https://github.com/MapStory/mapstory/wiki/CSS-Styleguide) like using `!important`, applying negative margins, using more than two selectors, etc. (as does the original CSS before I did this work). I felt it was more important to address the bug quickly for production, and a more thorough refactor of the way our nav is written can be handled separately (new stories to follow).

The problems addressed in this PR include:
- Hiding the user avatar from the mobile menu so that it doesn't look strange/make the menu more difficult to use in a touch device context.
- Allow the mobile menu to be any height so that the user can scroll on their device naturally, rather than showing scrollbars within the menu itself (which may be difficult to use on some touch devices, especially if the user is an admin and looking at the admin menu).
- The height of the navigation for tablet and desktop sizes stays consistent. I added new media breakpoints, changed font sizes, and changed the width of the quick search bar to achieve this.
- Updated spacing in the CSS files I touched to follow the 4-space indent rule stated in our style guide.
- Changed the hamburger menu to say "Menu", which provides a better user experience. The use of a hamburger menu icon is widely acknowledged as confusing and poor UX. There are many articles about this that have been written and shared in the UX community. Here's one: http://jamesarcher.me/hamburger-menu


# Before

### Mobile
![screen shot 2017-03-08 at 11 59 57 am](https://cloud.githubusercontent.com/assets/1529366/23716730/e008346e-03f6-11e7-9aea-9b6925b8f26e.png)

With profile menu open:
![screen shot 2017-03-08 at 12 00 41 pm](https://cloud.githubusercontent.com/assets/1529366/23716741/eef5d3fa-03f6-11e7-9cb4-d3d401cf35b6.png)

### Tablet
![screen shot 2017-03-08 at 12 02 36 pm](https://cloud.githubusercontent.com/assets/1529366/23716809/257f80b0-03f7-11e7-8210-0b48975e22ee.png)

### Small desktop
![screen shot 2017-03-08 at 12 02 58 pm](https://cloud.githubusercontent.com/assets/1529366/23716821/314d5372-03f7-11e7-85fd-95e3a4289b12.png)

### Desktop > 1200px wide
![screen shot 2017-03-08 at 12 03 17 pm](https://cloud.githubusercontent.com/assets/1529366/23716842/418d2d3e-03f7-11e7-9a16-1ac8d00cfd81.png)


# After

### Mobile
![screen shot 2017-03-08 at 12 01 23 pm](https://cloud.githubusercontent.com/assets/1529366/23716765/00ade0a6-03f7-11e7-8906-e2b5a1467d34.png)

With profile menu open:
![screen shot 2017-03-08 at 12 01 33 pm](https://cloud.githubusercontent.com/assets/1529366/23716775/1087dc2a-03f7-11e7-8f58-91fabe75607d.png)

### Tablet
![screen shot 2017-03-08 at 12 04 39 pm](https://cloud.githubusercontent.com/assets/1529366/23716895/7065dcbe-03f7-11e7-8946-2f2b0490759f.png)

### Small desktop
![screen shot 2017-03-08 at 12 05 22 pm](https://cloud.githubusercontent.com/assets/1529366/23716926/861070c4-03f7-11e7-818e-d0c98b0868ea.png)

### Desktop > 1200px wide
![screen shot 2017-03-08 at 12 05 53 pm](https://cloud.githubusercontent.com/assets/1529366/23716955/9cab9eda-03f7-11e7-8183-c745953d8c3e.png)
