### PR TITLE
Add scroll to overlay and reduce max height

### DIFF
--- a/mapstory/static/style/maps/viewer.less
+++ b/mapstory/static/style/maps/viewer.less
@@ -325,8 +325,9 @@ body.ms-fullscreen .gxp-annotations-tip {
 
 .ol-popup-content {
     min-width: 170px;
-    max-height: 200px;
+    max-height: 150px;
     overflow-x: auto;
+    overflow-y: scroll;
 }
 
 .ol-popup-closer {


### PR DESCRIPTION
This PR addresses the problem described in https://github.com/MapStory/mapstory/issues/524 in part.

It adds overflow/scroll behavior to the overlay and also reduces the max height of the div in order to reduce out of bounds conflict.