### PR TITLE
Add new navigation, styles, and footer styles

### DIFF
--- a/mapstory/static/style/site/base.less
+++ b/mapstory/static/style/site/base.less
@@ -14,8 +14,6 @@ body {
   font-size: 16px;
   line-height: 22px;
   font-family: "Open Sans", Helvetica, sans-serif;
-  padding-top: 40px;
-  background: @gray90;
   -webkit-font-smoothing: antialiased; /* Fix for webkit rendering */
   -webkit-text-size-adjust: 100%;
 }

--- a/mapstory/static/style/site/navbar-footer.less
+++ b/mapstory/static/style/site/navbar-footer.less
@@ -1,144 +1,446 @@
-.navbar-header {
-    .navbar-toggle {
-        text-transform: uppercase;
-        float: right;
-        font-size: 0.9em;
-        margin: 13px;
-    }
+.logo-wrapper {
+    position: relative;
+    width: 200px;
+    margin-top: 5px;
 }
 
-.navbar-collapse {
-    max-height: none !important;
-}
-
-
-/*--- NavBar ---*/
-
-.navbar-logo {
-    width: 195px;
-    @media only screen and (max-width: 768px) {
-        // For small screens when nav changes to collapsed hamburger menu
-        margin: 0 20px;
-    }
-}
-
-.navbar-brand {
-    background-size: 100%;
-    width: 196px;
-    margin: 10px 10px 0;
-    text-indent: -9999em;
+h1.site-title {
+    width: 200px;
+    height: 45px;
+    text-indent: -9999px;
+    margin: 0;
+    float: left;
 }
 
 .beta-tag {
     text-transform: uppercase;
     font-family: "Lato", Helvetica, sans-serif;
     clear: both;
-    color: #999;
+    color: @gray-500;
     font-size: 10px;
-    float: right;
-    margin: -23px 30px;
-    @media only screen and (max-width: 768px) {
-        // For small screens when nav changes to collapsed hamburger menu
-        margin: -23px 5px;
-    }
-}
-
-.navbar-nav > li > a {
-    font-weight: 500;
-    padding-top: 25px;
-    cursor: pointer;
-    @media @tablets {
-        font-size: 0.85em;
-    }
-    @media @desktops {
-        font-size: 0.9em;
-    }
-    @media only screen and (min-width: 1200px) {
-        font-size: 1em;
-    }
-}
-
-.navbar .search {
-    width: 220px;
-    margin-left: -15px;
-    margin-top: 10px;
-    @media only screen and (min-width: 1200px) {
-        width: 285px;
-    }
-}
-
-.dropdown-menu {
-    border-radius: 4px;
-    border: none;
-    padding: 8px 15px;
-}
-
-.nav-icon {
-    font-size: 1.3em;
+    position: absolute;
+    top: 27px;
+    right: 16px;
 }
 
 .nav-avatar {
-    margin: -8px -10px;
-    @media only screen and (max-width: 768px) {
-        display: none !important;
-    }
-    @media @tablets, @desktops {
-        margin-left: 25px;
-        margin-right: -10px;
-    }
-}
-
-#createDropdown {
     display: none;
-    @media @tablets, @desktops {
-        display: block;
-    }
-}
 
-.quicksearchcontainer {
-    display: none;
     @media @desktops {
-        display: block;
-        width: 200px;
-        input[type='text'] {
-            width: 190px;
-        }
-        .input-group-btn {
-            width: 20%;
-        }
-    }
-    @media only screen and (min-width: 1200px) {
-        width: 290px;
-        input[type='text'] {
-            width: 230px !important;
-        }
+        display: inline;
+        width: 25px;
+        border-radius: 50%;
+        border: 1px solid @gray-800;
+        margin: 2px 8px 8px 8px;
     }
 }
 
-.quicksearchcontainer .fa-search{
-    padding: 3px 0;
+li.divider {
+    @media @desktops {
+        background-color: @gray-900;
+        margin-right: 15px;
+        height: 1px;
+    }
 }
 
-#logout_form {
-    text-align: right;
-    padding-right: 15px;
-}
+header.navigation {
+    @base-border-color: red;
+    @base-border-radius: 6px;
+    @action-color: blue;
+    @navigation-padding: 1em;
+    @navigation-background: @gray-950;
+    @navigation-color: @gray-400;
+    @navigation-color-hover: @white;
+    @navigation-height: 50px;
+    @navigation-nav-button-background: @action-color;
+    @navigation-nav-button-background-hover: shade(@navigation-background, 50%);
+    @navigation-nav-button-border: 1px solid shade(@navigation-nav-button-background, 20%);
+    @navigation-search-background: @gray-50;
+    @navigation-search-border: 1px solid @gray-200;
+    @navigation-active-link-color: @white;
+    @navigation-submenu-padding: 1em;
+    @navigation-submenu-width: 12em;
 
-/*--- Footer ---*/
-
-footer {
-    color: @gray55;
-    background: @primary;
-    border-top: 1px solid @gray40;
-    padding: 20px 10px;
+    background: @navigation-background; // Fallback for IE9 since it doesn't support gradients
+    background: @navigation-gradient;
+    min-height: @navigation-height;
     width: 100%;
+    z-index: 999;
+
+    .navigation-wrapper {
+        clear: both;
+        position: relative;
+        // Modals have z-index 1050, so anything > 1050 will show menus
+        // and other nav elements on top of modals, which is bad
+        z-index: 1000;
+    }
+
+    // Mobile view
+
+    .navigation-menu-button {
+        font-family: @base-font-family;
+        font-weight: 400;
+        font-size: 0.85em;
+        color: @navigation-color;
+        display: block;
+        float: right;
+        line-height: @navigation-height;
+        margin: 0;
+        padding-right: 1em;
+        text-decoration: none;
+        text-transform: uppercase;
+
+        @media @desktops {
+            display: none;
+        }
+
+        &:focus,
+        &:hover {
+            color: @navigation-color-hover;
+        }
+    }
+
+    // Nav menu
+
+    nav {
+        float: none;
+        min-height: @navigation-height;
+        z-index: 9999999;
+
+        @media @desktops {
+            float: right;
+
+        }
+    }
+
+    ul.navigation-menu {
+        clear: both;
+        display: none;
+        margin: 0 auto;
+        overflow: visible;
+        padding: 0;
+        width: 100%;
+        z-index: 9999;
+
+        &.show {
+            display: block;
+        }
+
+        @media @desktops {
+            display: inline;
+            margin: 0 0 0 40px;
+            padding: 0;
+        }
+    }
+
+    // The nav items
+
+    ul li.nav-link {
+        font-family: @base-font-family;
+        font-weight: 400;
+        font-size: 0.85em;
+        display: block;
+        line-height: @navigation-height;
+        overflow: hidden;
+        padding-right: 0.8em;
+        text-align: left;
+        width: 100%;
+        z-index: 9999;
+
+        @media @desktops {
+            background: transparent;
+            display: inline;
+            line-height: @navigation-height;
+            text-decoration: none;
+            width: auto;
+            text-align: right;
+
+            &.mobile-menu-only {
+                display: none;
+            }
+        }
+
+        a {
+            color: @navigation-color;
+            display: inline-block;
+            text-decoration: none;
+
+            @media @desktops {
+                padding-right: 1em;
+            }
+
+            &:focus,
+            &:hover {
+                color: @navigation-color-hover;
+                &:after {
+                    color: @gray-50;
+                }
+            }
+        }
+    }
+
+    .active-nav-item a {
+        border-bottom: 1px solid @navigation-active-link-color;
+        padding-bottom: 3px;
+    }
+
+    // Sub menus
+
+    li.more.nav-link {
+        padding-right: 0;
+
+        @media @desktops {
+            padding-right: @navigation-submenu-padding;
+        }
+
+        > ul > li:first-child a  {
+            padding-top: 5px;
+        }
+
+        a {
+            margin-right: @navigation-submenu-padding;
+        }
+
+        > a {
+            padding-right: 0.6em;
+        }
+
+        > a::after {
+            color: @navigation-color;
+            content: "\25BE";
+            position: absolute;
+            right: -5px;
+            font-size: 0.85em;
+        }
+
+        &.user-menu > a::after {
+            color: @navigation-color;
+            top: -16px;
+            right: 5px;
+        }
+
+        &.user-menu {
+            .mobile-menu-only {
+                position: relative;
+                display: inline;
+                &:after {
+                    top: -16px;
+                    right: -5px;
+                }
+            }
+
+            .desktop-menu-only {
+                display: none;
+            }
+
+            @media @desktops {
+                .mobile-menu-only {
+                    display: none;
+                }
+                .desktop-menu-only {
+                    display: inline;
+                }
+            }
+        }
+
+        &.user-menu:hover {
+            a::after {
+                color: @gray-50;
+            }
+        }
+    }
+
+    li.more {
+        overflow: visible;
+        padding-right: 0;
+
+        a {
+            padding-right: 0.8em;
+        }
+
+        > a {
+            padding-right: 1.6em;
+            position: relative;
+
+            @media @desktops {
+                margin-right: @navigation-submenu-padding;
+            }
+
+            &::after {
+                content: "›";
+                font-size: 1.2em;
+                position: absolute;
+                right: @navigation-submenu-padding / 2;
+            }
+        }
+
+
+        @media @desktops {
+            padding-right: 0.8em;
+            position: relative;
+        }
+    }
+
+    ul.submenu {
+        display: none;
+        padding-left: 0;
+
+        @media @desktops {
+            left: -@navigation-submenu-padding;
+            position: absolute;
+            top: 1.5em;
+            z-index: 1;
+        }
+
+        .submenu.fly-out-right {
+            @media @desktops {
+                left: @navigation-submenu-width - 0.2em;
+                top: 0;
+            }
+        }
+
+        .submenu.fly-out-left {
+            @media @desktops {
+                left: -@navigation-submenu-width + 0.2em;
+                top: 0;
+            }
+        }
+
+        .submenu {
+            @media @desktops {
+                left: @navigation-submenu-width - 0.2em;
+                top: 0;
+            }
+        }
+
+        li {
+            display: block;
+            padding-right: 0;
+            font-family: @base-font-family;
+            font-weight: 400;
+            font-size: 0.85em;
+
+            @media @desktops {
+                line-height: @navigation-height / 1.3;
+
+                &:first-child > a {
+                    border-top-left-radius: @base-border-radius;
+                    border-top-right-radius: @base-border-radius;
+                }
+
+                &:last-child > a, &:last-child > form > a {
+                    border-bottom-left-radius: @base-border-radius;
+                    border-bottom-right-radius: @base-border-radius;
+                    padding-bottom: 0.7em;
+                }
+            }
+
+            a {
+                display: inline-block;
+                text-align: left;
+                width: 100%;
+                padding-left: 30px;
+
+                @media @desktops {
+                    background-color: @navigation-background;
+                    padding-left: @navigation-submenu-padding;
+                    text-align: left;
+                    width: @navigation-submenu-width;
+                }
+            }
+        }
+    }
+
+    // Elements on the far right
+
+    .navigation-tools {
+        clear: both;
+        display: block;
+        height: @navigation-height;
+
+        @media @desktops {
+            background: transparent;
+            clear: none;
+            float: right;
+        }
+    }
+
+    // Search bar
+
+    .search-bar {
+        float: right;
+        padding: 8px;
+        width: 100%;
+
+        form {
+            position: relative;
+
+            input[type=search] {
+                font-family: @base-font-family;
+                font-weight: 400;
+                font-size: 0.85em;
+                background: @navigation-search-background;
+                border: @navigation-search-border;
+                border-radius: @base-border-radius;
+                box-sizing: border-box;
+                color: @gray-900;
+                font-style: italic;
+                margin: 0;
+                padding: 3px 8px;
+                width: 100%;
+
+                @media @desktops {
+                    width: 100%;
+                }
+            }
+
+            button[type=submit] {
+                background: @navigation-search-background;
+                border: 0;
+                bottom: 0.3em;
+                left: auto;
+                outline: none;
+                padding: 0 9px;
+                position: absolute;
+                right: 0.3em;
+                top: 0.3em;
+                color: @gray-700;
+
+                img {
+                    height: 12px;
+                    opacity: 0.7;
+                    padding: 1px;
+                }
+            }
+        }
+
+        @media @desktops {
+            display: inline-block;
+            position: relative;
+            width: 16em;
+
+            input {
+                box-sizing: border-box;
+                display: block;
+            }
+        }
+    }
 }
 
-.footerWidget {
-    color: @white;
-}
 
-select .lang {
-    background-color: transparent;
-    color: @white;
+// Footer
+
+footer.site-footer {
+    color: @gray-300;
+    background: @gray-950;
+    font-family: @base-font-family;
+    font-weight: 400;
+    font-size: 0.9em;
+    padding: 2em 0;
+
+    .version-number {
+        color: @gray-600;
+        font-size: 0.8em;
+        float: right;
+    }
 }

--- a/mapstory/static/style/site/variables.less
+++ b/mapstory/static/style/site/variables.less
@@ -27,3 +27,29 @@
 @gray30: mix(@black, @white, 70%);
 @gray20: mix(@black, @white, 80%);
 @gray10: mix(@black, @white, 90%);
+
+@gray-0: #ffffff;
+@gray-25: #fafafa;
+@gray-50: #f5f5f5;
+@gray-100: #eeeeee;
+@gray-200: #e7e7e7;
+@gray-300: #e0e0e0;
+@gray-400: #d8d8d8;
+@gray-500: #bdbdbd;
+@gray-600: #9e9e9e;
+@gray-700: #757575;
+@gray-800: #616161;
+@gray-900: #424242;
+@gray-950: #333333;
+@gray-975: #212121;
+@gray-1000: #000000;
+
+@blue-300: #0e83e8;
+@blue-500: #0f6cba;
+
+// Typography
+
+@base-font-family: 'Lato', Helvetica, Arial, sans-serif;
+@base-font-size: 1em;
+@base-font-color: @gray-950;
+@base-line-height: 1.5;

--- a/mapstory/static/style/themes/blue/brandcolors.less
+++ b/mapstory/static/style/themes/blue/brandcolors.less
@@ -1,8 +1,10 @@
 // === BRANDED THEME VARIABLES GO HERE ====
-@primary: #162f43; 
+@primary: #162f43;
 @primary-highlight: lighten(@primary, 10%);
 @primary-shadow: darken(@primary, 10%);
 
 @secondary: #162f43;
 @secondary-highlight: lighten(@secondary, 10%);
 @secondary-shadow: darken(@secondary, 10%);
+
+@navigation-gradient: linear-gradient(107deg, #151617 20%, #1d5aa7 140%);

--- a/mapstory/static/style/themes/default/brandcolors.less
+++ b/mapstory/static/style/themes/default/brandcolors.less
@@ -6,3 +6,5 @@
 @secondary: #444444;
 @secondary-highlight: lighten(@secondary, 10%);
 @secondary-shadow: darken(@secondary, 10%);
+
+@navigation-gradient: linear-gradient(107deg, #333333 8%, #1C505C 140%);

--- a/mapstory/static/style/themes/orange/brandcolors.less
+++ b/mapstory/static/style/themes/orange/brandcolors.less
@@ -1,8 +1,10 @@
 // === BRANDED THEME VARIABLES GO HERE ====
-@primary: #f59620; 
+@primary: #f59620;
 @primary-highlight: lighten(@primary, 10%);
 @primary-shadow: darken(@primary, 6%);
 
-@secondary: #e46e25; 
+@secondary: #e46e25;
 @secondary-highlight: lighten(@secondary, 10%);
 @secondary-shadow: darken(@secondary, 6%);
+
+@navigation-gradient: linear-gradient(107deg, #383635 8%, #f1642e 140%);

--- a/mapstory/templates/_footer.html
+++ b/mapstory/templates/_footer.html
@@ -1,43 +1,26 @@
 {% load i18n %}
-<footer id="sitebase_footer">
-    <section>
-        <div class="container">
-            <div class="row">
-                <div class="col-sm-12">
-                    <div class="footerWidget">
-                        {{ site.assets.footer_text |safe }}
-                    </div>
-                </div>
-            </div>
+<footer class="site-footer">
+    <div class="container">
+        {{ site.assets.footer_text |safe }}
+        <div class="version-number">
+            {% trans "version" %} {{ VERSION }}
         </div>
-    </section>
-    <section>
-        <div class="container">
-            <hr>
-            <div class="row">
-                <div class="col-sm-8">
-                    {% trans "version" %} {{ VERSION }}
-                </div>
-                <div class="col-sm-4">
+    </div>
     {% if THEME == 'default' %}
     {# only show language trans in development environment until bugs fixed #}
-                    <label class="hidden">{% trans "Language" %}</label>
-                    {% if csrf_token != "NOTPROVIDED" %}
-                        {% get_current_language as LANGUAGE %}
-                        <form class="form-inline" action="/i18n/setlang/" method="post">
-                            {% csrf_token %}
-                            <select class="lang col-md-6 pull-right" name="language" onchange="javascript:form.submit()">
-                                {% for lang in LANGUAGES %}
-                                    <option value="{{ lang.0 }}" {% ifequal LANGUAGE_CODE lang.0 %} selected="selected"{% endifequal %}>
-                                        {{ lang.1 }}
-                                    </option>
-                                {% endfor %}
-                            </select>
-                        </form>
-                    {% endif %}
+        <label class="hidden">{% trans "Language" %}</label>
+        {% if csrf_token != "NOTPROVIDED" %}
+            {% get_current_language as LANGUAGE %}
+            <form action="/i18n/setlang/" method="post">
+                {% csrf_token %}
+                <select name="language" onchange="javascript:form.submit()">
+                    {% for lang in LANGUAGES %}
+                        <option value="{{ lang.0 }}" {% ifequal LANGUAGE_CODE lang.0 %} selected="selected"{% endifequal %}>
+                            {{ lang.1 }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </form>
+        {% endif %}
     {% endif %}
-                </div>
-            </div>
-        </div>
-    </section>
 </footer>

--- a/mapstory/templates/_header.html
+++ b/mapstory/templates/_header.html
@@ -1,76 +1,27 @@
 {% load i18n avatar_tags %}
-<nav class="navbar navbar-default navbar-fixed-top" role="navigation">
-    <div class="container">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false"
-                    aria-controls="navbar">
-                <span class="sr-only">Toggle navigation</span>
-                Menu
-            </button>
-            {% if site.assets.logo %}
-                <div class="navbar-logo">
-                    <a class="navbar-brand"
-                       style="background:url('{{ MEDIA_URL }}{{ site.assets.logo.name }}') no-repeat; background-size:100%;"
-                       href="{% url "home" %}">{{ SITE_NAME }}</a>
-                    {% if THEME == 'orange' %}
-                        <div class="beta-tag">Beta</div>
-                    {% endif %}
-                </div>
-            {% endif %}
-        </div>
-        <div id="navbar" class="navbar-collapse collapse">
-            <ul class="nav navbar-nav navbar-right">
-                {% if user.is_authenticated %}
-                    <li class="nav-avatar">
-                        <a href="{% url 'profile_detail' slug=user.username %}">
-                            <img class="img-circle" src="{% avatar_url user 35 %}"/>
-                        </a>
-                    </li>
-                    <li class="dropdown"><a href="#" id="id_userlink" class="dropdown-toggle" data-toggle="dropdown">{{ user.username }}<b class="caret"></b></a>
-                        <ul class="dropdown-menu">
-                            <li><a href="{% url 'profile_detail' slug=user.username %}">{% trans "Profile" %}</a></li>
-                            <li class="divider"></li>
-                            <li><a href="{% url 'edit_profile' user.username %}">{% trans "Edit Profile" %}</a></li>
-                            <li><a href="{% url 'account_password' %}">{% trans "Change Password" %}</a> </li>
-                            <li><a href="{% url 'profile_detail' slug=user.username %}?showNotifications=true">{% trans "Notification Settings" %}</a></li>
-                            <li class="divider"></li>
-                            <li><a href="{% url 'getpage' 'started' %}">{% trans "Help" %}</a></li>
-                            <li class="divider"></li>
-                        {% if user.is_staff %}
-                            <li><a href="{% url 'admin:index' %}">{% trans "Admin Panel" %}</a></li>
-                        {% endif %}
-                        {% if perms.announcements.can_manage %}
-                            <li><a href="{% url 'announcements_list' %}">{% trans "Announcements" %}</a></li>
-                        {% endif %} 
-                        {% if user.is_superuser %}
-                            <li><a href="{% url 'account_invite_user' %}">{% trans "Invite User" %}</a></li>
-                            <li><a href="{% url 'services' %}">{% trans "Remote Services" %}</a></li>
-                            <li><a href="{{ GEOSERVER_BASE_URL }}">{% trans "GeoServer" %}</a></li>
-                            <li class="divider"></li>
-                        {% endif %} 
-                            <li>
-                                <form action="{% url 'account_logout' %}" id="logout_form" method="post">
-                                    {% csrf_token %}
-                                    <a href="javascript:{}" onclick="document.getElementById('logout_form').submit();">
-                                        <i class="fa fa-sign-out"></i> {% trans "Log out" %}</a>
-                                </form>
-                            </li>
-                        </ul>
-                    </li>
-                {% else %}
-                    <li>
-                        <a role="button" class="nav-icon" data-toggle="modal" data-target="#loginModal">
-                            <i class="fa fa-user"></i>
-                        </a>
-                    </li>
+<header class="navigation" role="banner">
+    <div class="navigation-wrapper container">
+        {% if site.assets.logo %}
+            <div class="logo-wrapper">
+                <a href="{% url "home" %}">
+                    <h1 class="site-title" style="background:url('{{ MEDIA_URL }}{{ site.assets.logo.name }}') no-repeat; background-size:100%;">
+                        {{ SITE_NAME }}
+                    </h1>
+                </a>
+                {% if THEME == 'orange' %}
+                    <div class="beta-tag">Beta</div>
                 {% endif %}
-            </ul>
-            <ul class="nav navbar-nav navbar-right">
-                <li><a href="{% url 'search' %}">{% trans "Explore" %}</a></li>
-                <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
-                       aria-expanded="false">{% trans 'Create' %}<span class="caret"></span></a>
-                    <ul class="dropdown-menu">
+            </div>
+        {% endif %}
+
+        <a href="javascript:void(0)" class="navigation-menu-button" id="js-mobile-menu" aria-expanded="false" area-controls="navbar">MENU</a>
+        <nav role="navigation">
+            <ul id="js-navigation-menu" class="navigation-menu show">
+
+                <li class="nav-link"><a href="{% url 'search' %}">{% trans "Explore" %}</a></li>
+                <li id="js-navigation-more" class="nav-link more">
+                    <a href="javascript:void(0)">{% trans 'Create' %}</a>
+                    <ul class="submenu">
                         {% if user.is_authenticated %}
                             <li>
                                 <a class="pointer" ng-controller="ImportController"
@@ -83,7 +34,9 @@
                             <li>
                                 <a href="{% url 'upload' %}">{% trans "Upload Icons" %}</a>
                             </li>
-                            <li><a href="{% url 'new_map' %}?tour">{% trans "Compose Story" %}</a></li>
+                            <li>
+                                <a href="{% url 'new_map' %}?tour">{% trans "Compose Story" %}</a>
+                            </li>
                         {% else %}
                             <li><a href="#" data-toggle="modal" data-target="#loginModal">{% trans "Import Layer" %}</a></li>
                             <li><a href="#" data-toggle="modal" data-target="#loginModal">{% trans "Create Layer" %}</a></li>
@@ -92,29 +45,78 @@
                         {% endif %}
                     </ul>
                 </li>
-                <li><a href="{% url 'getpage' 'started' %}">{% trans "Get Started" %}</a></li>
-                <li><a href="{% url 'journal' %}">{% trans "Journal" %}</a></li>
-                <li>
-                    <form class="navbar-form quicksearchcontainer" id="search" action="{% url 'search' %}">
-                        <div class="col-md-3 search">
-                            <div class="input-group">
-                                <input id="quicksearch" type="text" class="form-control" 
-                                    placeholder="Quick Search"
-                                    {% if HAYSTACK_SEARCH %} name="q" 
-                                    {% else %} name="keywords__slug__in"
-                                    {% endif %}
-                                >
-                                <span class="input-group-btn">
-                                    <button class="btn btn-primary" type="submit">
-                                        <i class="fa fa-search"></i>
-                                    </button>
-                                </span>
-                            </div>
+                <li class="nav-link"><a href="{% url 'getpage' 'started' %}">{% trans "Get Started" %}</a></li>
+                <li class="nav-link"><a href="{% url 'journal' %}">{% trans "Journal" %}</a></li>
+
+                {% if user.is_authenticated %}
+                    <li id="js-navigation-more" class="nav-link more user-menu">
+                        <a href="javascript:void(0)" class="desktop-menu-only">
+                            <img class="nav-avatar" src="{% avatar_url user 35 %}"/>
+                        </a>
+                        <a href="javascript:void(0)" class="mobile-menu-only">
+                            {{ user.username }}
+                        </a>
+                        <ul class="submenu">
+                            <li><a href="{% url 'profile_detail' slug=user.username %}">{{ user.username }}</a></li>
+                            <li class="divider"></li>
+                            <li><a href="{% url 'edit_profile' user.username %}">{% trans "Edit Profile" %}</a></li>
+                            <li><a href="{% url 'account_password' %}">{% trans "Change Password" %}</a></li>
+                            <li><a href="{% url 'profile_detail' slug=user.username %}?showNotifications=true">{% trans "Notification Settings" %}</a></li>
+                            <li class="divider"></li>
+                            <li><a href="{% url 'getpage' 'started' %}">{% trans "Help" %}</a></li>
+                            <li class="divider"></li>
+                        {% if user.is_staff %}
+                            <li><a href="{% url 'admin:index' %}">{% trans "Admin Panel" %}</a></li>
+                        {% endif %}
+                        {% if perms.announcements.can_manage %}
+                            <li><a href="{% url 'announcements_list' %}">{% trans "Announcements" %}</a></li>
+                        {% endif %}
+                        {% if user.is_superuser %}
+                            <li><a href="{% url 'account_invite_user' %}">{% trans "Invite User" %}</a></li>
+                            <li><a href="{% url 'services' %}">{% trans "Remote Services" %}</a></li>
+                            <li><a href="{{ GEOSERVER_BASE_URL }}">{% trans "GeoServer" %}</a></li>
+                            <li class="divider"></li>
+                        {% endif %}
+                            <li class="desktop-menu-only">
+                                <form action="{% url 'account_logout' %}" id="logout_form" method="post">
+                                    {% csrf_token %}
+                                    <a href="javascript:{}" onclick="document.getElementById('logout_form').submit();">
+                                        {% trans "Log out" %}
+                                    </a>
+                                </form>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="nav-link mobile-menu-only">
+                        <form action="{% url 'account_logout' %}" id="logout_form" method="post">
+                            {% csrf_token %}
+                            <a href="javascript:{}" onclick="document.getElementById('logout_form').submit();">
+                                {% trans "Log out" %}
+                            </a>
+                        </form>
+                    </li>
+                {% else %}
+                    <li class="nav-link"><a data-toggle="modal" data-target="#loginModal">{% trans "Log In" %}</a></li>
+                {% endif %}
+            </ul>
+            <div class="navigation-tools">
+                <div class="search-bar">
+                    <form action="{% url 'search' %}" role="search">
+                        <div>
+                            <input type="search"
+                                placeholder="Quick Search"
+                                {% if HAYSTACK_SEARCH %} name="q"
+                                {% else %} name="keywords__slug__in"
+                                {% endif %}
+                            >
+                            <button class="btn" type="submit">
+                                <i class="fa fa-search"></i>
+                            </button>
                         </div>
                     </form>
-                </li>
-            </ul>
-        </div><!--/.nav-collapse -->
-    </div><!--/.container-fluid -->
-</nav>
+                </div>
+            </div>
+        </nav>
+    </div>
+</header>
 {% if not hide_menu %} {% include '_login_register.html' %} {% endif %}

--- a/mapstory/templates/_site_scripts.html
+++ b/mapstory/templates/_site_scripts.html
@@ -11,6 +11,57 @@
 <script src="{{ STATIC_URL }}vendor/angular-slick/dist/slick.js"></script>
 <script src="{{ STATIC_URL }}geonode/js/search/explore.js"></script>
 <script src="{{ STATIC_URL }}mapstory/js/search.js"></script>
+
+<!-- Script for animating navigation submenus -->
+<script type="text/javascript">
+    $(window).resize(function() {
+        var more = document.getElementById("js-navigation-more");
+        if ($(more).length > 0) {
+            var windowWidth = $(window).width();
+            var moreLeftSideToPageLeftSide = $(more).offset().left;
+            var moreLeftSideToPageRightSide = windowWidth - moreLeftSideToPageLeftSide;
+
+            if (moreLeftSideToPageRightSide < 330) {
+                $("#js-navigation-more .submenu .submenu").removeClass("fly-out-right");
+                $("#js-navigation-more .submenu .submenu").addClass("fly-out-left");
+            }
+
+            if (moreLeftSideToPageRightSide > 330) {
+                $("#js-navigation-more .submenu .submenu").removeClass("fly-out-left");
+                $("#js-navigation-more .submenu .submenu").addClass("fly-out-right");
+            }
+        }
+    });
+
+    $(document).ready(function() {
+        var menuToggle = $("#js-mobile-menu").unbind();
+        var submenuToggle = $(".nav-link.more").unbind();
+
+        $("#js-navigation-menu").removeClass("show");
+
+        menuToggle.on("click", function(e) {
+            e.preventDefault();
+            $("#js-navigation-menu").slideToggle(function() {
+                if($("#js-navigation-menu").is(":hidden")) {
+                    $("#js-navigation-menu").removeAttr("style");
+                }
+            });
+        });
+
+    submenuToggle.on("click", function(e) {
+        thisSubmenu = $(this).children(".submenu");
+        otherSubmenus = $(this).siblings().children(".submenu");
+        otherSubmenus.slideUp();
+        thisSubmenu.slideToggle();
+
+        $(this).mouseleave(function() {
+            thisSubmenu.slideUp();
+        });
+    });
+});
+</script>
+<!-- end script for animating navigation submenus -->
+
 <script type="text/javascript">
     CATEGORIES_ENDPOINT = '{% url 'api_dispatch_list' api_name='api' resource_name='categories' %}';
     KEYWORDS_ENDPOINT = '{% url 'api_dispatch_list' api_name='api' resource_name='keywords' %}';

--- a/mapstory/templates/site_base.html
+++ b/mapstory/templates/site_base.html
@@ -31,25 +31,23 @@
             <h1>You are using an outdated browser that is not supported by GeoNode.</h1>
             <p>Please use a <strong>modern browser</strong> like Mozilla Firefox, Google Chrome or Safari.</p>
         </div>
-        <div id="wrap">
-            {% block middle %}
-                <div class="container">
-                    {% include "_status_message.html" %}
-                    {% include "_announcements.html" %}
-                    {% include "_messages.html" %}
-                    {% block body_outer %}
-                        <div class="row">
-                            <div class="col-md-8">
-                                {% block body %}{% endblock %}
-                            </div>
-                            <div class="col-md-4">
-                                {% block sidebar %}{% endblock %}
-                            </div>
+        {% block middle %}
+            <div class="container">
+                {% include "_status_message.html" %}
+                {% include "_announcements.html" %}
+                {% include "_messages.html" %}
+                {% block body_outer %}
+                    <div class="row">
+                        <div class="col-md-8">
+                            {% block body %}{% endblock %}
                         </div>
-                    {% endblock %}
-                </div>
-            {% endblock middle %}
-        </div>
+                        <div class="col-md-4">
+                            {% block sidebar %}{% endblock %}
+                        </div>
+                    </div>
+                {% endblock %}
+            </div>
+        {% endblock middle %}
         {% block footer %}{% include '_footer.html' %}{% endblock footer%}
         {% include "_site_scripts.html" %}
         {% block extra_script %}{% endblock extra_script %}

--- a/mapstory/tests/unit/forms/test_Organizations.py
+++ b/mapstory/tests/unit/forms/test_Organizations.py
@@ -25,5 +25,5 @@ class TestOrganizations(MapStoryTestMixin):
         soup = BeautifulSoup(response.content)
 
         # Should have 28 fields total
-        self.assertEqual(len(soup.find_all('input')), 27)
+        self.assertEqual(len(soup.find_all('input')), 28)
 

--- a/mapstory/tests/unit/forms/test_Organizations.py
+++ b/mapstory/tests/unit/forms/test_Organizations.py
@@ -25,5 +25,5 @@ class TestOrganizations(MapStoryTestMixin):
         soup = BeautifulSoup(response.content)
 
         # Should have 28 fields total
-        self.assertEqual(len(soup.find_all('input')), 28)
+        self.assertEqual(len(soup.find_all('input')), 27)
 

--- a/mapstory/tests/unit/forms/test_Organizations.py
+++ b/mapstory/tests/unit/forms/test_Organizations.py
@@ -25,5 +25,5 @@ class TestOrganizations(MapStoryTestMixin):
         soup = BeautifulSoup(response.content)
 
         # Should have 28 fields total
-        self.assertEqual(len(soup.find_all('input')), 28)
+        self.assertEqual(len(soup.find_all('input')), 29)
 


### PR DESCRIPTION
This resolves #534.

This PR covers:
* Creating larger touch zones so the menu is easier to use on mobile touch devices.
* Making the navigation more visually distinct from the content area of the site.
* Showing the logout link at the top level of the mobile menu, rather than within a submenu.
* Quick search now shows on mobile sizes instead of hiding.
* Improved code quality by eliminating `!important`, unnecessary specificity, overrides, classes and divs that don't provide functionality or styling, etc. 
* Navigation pattern no longer follows Bootstrap, and now uses the Bourbon Refills library + customization.
* The user menu no longer shows a person or avatar when the user is not authenticated, and instead shows the words "Log in", which should provide a user experience.
* The user menu no longer shows the username, but instead shows only the avatar at desktop widths to prevent long usernames from causing the text in the navigation banner to wrap or increase the height of the container (see screenshots below). However, the username is still displayed at mobile sizes.
* Submenu items are indented so it's easier to understand visually that they are part of a section.

Here's what the new nav looks like:
# MapStory
### Desktop, menu closed with search terms entered (instead of placeholder text)
<img width="1420" alt="screen shot 2017-03-16 at 10 38 53 am" src="https://cloud.githubusercontent.com/assets/1529366/24019738/44c2a440-0a67-11e7-910a-032d8848556c.png">

### Desktop, submenu open
<img width="1421" alt="screen shot 2017-03-16 at 10 38 36 am" src="https://cloud.githubusercontent.com/assets/1529366/24019748/4eedd854-0a67-11e7-8cdf-0c4fa34778d1.png">

### Desktop, not logged in
<img width="1279" alt="screen shot 2017-03-16 at 4 50 59 pm" src="https://cloud.githubusercontent.com/assets/1529366/24020136/eaa53dea-0a68-11e7-946d-8900eba52332.png">

### Mobile, menu closed
<img width="384" alt="screen shot 2017-03-16 at 10 39 14 am" src="https://cloud.githubusercontent.com/assets/1529366/24019832/a45b2eb8-0a67-11e7-9138-d42252c74adf.png">

### Mobile, menu and submenu open
<img width="382" alt="screen shot 2017-03-16 at 10 39 05 am" src="https://cloud.githubusercontent.com/assets/1529366/24019729/38c41b56-0a67-11e7-8404-698c7614c17e.png">

### Mobile, not logged in
<img width="383" alt="screen shot 2017-03-16 at 4 51 08 pm" src="https://cloud.githubusercontent.com/assets/1529366/24020148/f4a3c154-0a68-11e7-8fbd-fad9e827bf1a.png">

# StoryScapes
### Desktop, menu closed
<img width="1424" alt="screen shot 2017-03-16 at 10 34 18 am" src="https://cloud.githubusercontent.com/assets/1529366/24019794/85eb1f56-0a67-11e7-8939-fc142dc9b487.png">

### Desktop, submenu open
<img width="1420" alt="screen shot 2017-03-16 at 10 35 45 am" src="https://cloud.githubusercontent.com/assets/1529366/24019764/62e72784-0a67-11e7-9739-e78f903c01e6.png">

### Mobile, submenu open
<img width="382" alt="screen shot 2017-03-16 at 10 34 57 am" src="https://cloud.githubusercontent.com/assets/1529366/24019773/7010ea26-0a67-11e7-8adc-4decc3b0d094.png">

*Note*: I worked with @zunware to try to get e2e tests running for this, but we weren't able to get them running, so we'll have to circle back and look at them for the navigation later.

I also tested this in Browser Stack to confirm that everything works for IE 9+, FF 31+, and Chrome 52.5+.