### PR TITLE
Prevent submenus from closing early

### DIFF
--- a/mapstory/static/style/site/navbar-footer.less
+++ b/mapstory/static/style/site/navbar-footer.less
@@ -191,6 +191,7 @@ header.navigation {
 
         @media @desktops {
             padding-right: @navigation-submenu-padding;
+            padding-bottom: @navigation-submenu-padding;
         }
 
         > ul > li:first-child a  {

--- a/mapstory/templates/_site_scripts.html
+++ b/mapstory/templates/_site_scripts.html
@@ -35,7 +35,7 @@
 
     $(document).ready(function() {
         var menuToggle = $("#js-mobile-menu").unbind();
-        var submenuToggle = $(".nav-link.more").unbind();
+        var submenuToggle = $("li.nav-link.more").unbind();
 
         $("#js-navigation-menu").removeClass("show");
 
@@ -54,7 +54,9 @@
         otherSubmenus.slideUp();
         thisSubmenu.slideToggle();
 
-        $(this).mouseleave(function() {
+        clicked = $(this);
+        menuElements = $(this).children(".nav-avatar");
+        $(clicked, menuElements).mouseleave(function() {
             thisSubmenu.slideUp();
         });
     });


### PR DESCRIPTION
This fixes #558 by tweaking the jQuery scope that triggers the submenus and adding additional padding to the bottom of the submenu `li`s so that a `mouseLeave` isn't triggered prematurely.