### PR TITLE
Fix Create Init Commit Bug

### DIFF
--- a/mapstory/importers.py
+++ b/mapstory/importers.py
@@ -58,6 +58,9 @@ class GeoServerLayerCreator(Import):
             feature_type = layer.get('featureType')
             datastore = feature_type['store']['name']
             store_create_geogig = layer.get(u'storeCreateGeogig', 'false')
+            owner = layer.get('layer_owner')
+            username = owner.username
+            email = owner.email
 
             feature_type['title'] = feature_type['name']
             feature_type['name'] = launder(slugify(unicode(feature_type['name'])))
@@ -67,7 +70,8 @@ class GeoServerLayerCreator(Import):
                 feature_type['nativeBoundingBox'] = {'minx': -180, 'maxx': 180, 'miny': -90, 'maxy': 90, 'crs': 'EPSG:4326'}
 
             if store_create_geogig and store_create_geogig != 'false':
-                store_created = create_geoserver_db_featurestore(store_type='geogig', store_name=feature_type['store']['name'])
+                store_created = create_geoserver_db_featurestore(store_type='geogig', store_name=feature_type['store']['name'], author_name=username,
+                                                                 author_email=email)
                 feature_type['store']['name'] = store_created.name
 
             if datastore not in getattr(settings, 'ALLOWED_DATASTORE_LAYER_CREATE', []) and '*' not in getattr(settings, 'ALLOWED_DATASTORE_LAYER_CREATE', []):


### PR DESCRIPTION
This resolves a bug where if a users first layer was a created one, future imported layers were attributed as imported by admin.  This resolves issue #504.