### PR TITLE
Fix StoryTeller URL

### DIFF
--- a/mapstory/templates/viewer/story_viewer.html
+++ b/mapstory/templates/viewer/story_viewer.html
@@ -353,8 +353,7 @@ opacity: 0
         <div class="content">
             {% verbatim %}
             <a target="_blank" href="/story/{{ mapManager.storyMap.get('id') - 1 }}/view" class="viewer-story-title" ng-bind="mapManager.title"></a>
-            {% endverbatim %}
-            <a target="_blank" href="/storyteller/{{ mapManager.username }}" class="viewer-author">{{ SITE_NAME }} {% verbatim %}by {{ mapManager.owner }}</a>
+            <a target="_blank" href="/storyteller/{{ mapManager.username }}" class="viewer-author">{% endverbatim %}{{ SITE_NAME }} {% verbatim %}by {{ mapManager.owner }}</a>
             <div class="viewer-chapter-number">Chapter {{ mapManager.storyChapter}}</div>
             <div class="viewer-chapter-title" ng-bind="mapManager.storyMap.getStoryTitle()"></div>
             <p ng-bind="mapManager.storyMap.getStoryAbstract()"></p>


### PR DESCRIPTION
The mapManager.username was being treated as Django, I needed to move a verbatim tag to fix the storyteller URL.