### PR TITLE
Change viewer idebar appearance when collapsed

### DIFF
--- a/mapstory/static/style/maps/viewer.less
+++ b/mapstory/static/style/maps/viewer.less
@@ -22,16 +22,36 @@ html, body {
     }
 }
 
+.expand-button {
+    display: none;
+}
+
 .sidebarHidden {
     display: block;
     position: absolute;
-    background: @gray97;
-    width: 20%;
+    background: transparent;
+    width: 28%;
     height: 100%;
     margin: 0;
     color: @gray40;
     left: -17.25%;
     z-index: 2;
+    display: inline;
+    .content {
+        display: none;
+    }
+    .expand-button {
+        float: right;
+        display: inline;
+        p {
+            font-family: @base-font-family;
+            color: @white;
+            font-size: 13px;
+            text-transform: uppercase;
+            padding-top: 6px;
+            float: left;
+        }
+    }
 }
 
 .sidebar p {
@@ -49,9 +69,6 @@ html, body {
     font-size: 15px;
     margin: 10px;
     cursor: pointer;
-    &.fa-caret-right {
-        display: none;
-    }
 }
 
 .sidebarHidden i {
@@ -63,8 +80,7 @@ html, body {
         display: none;
     }
     &.fa-caret-right {
-        cursor: pointer;
-        display: block;
+        display: inline;
     }
 }
 

--- a/mapstory/static/style/maps/viewer.less
+++ b/mapstory/static/style/maps/viewer.less
@@ -34,7 +34,7 @@ html, body {
     height: 100%;
     margin: 0;
     color: @gray40;
-    left: -17.25%;
+    left: -11.25%;
     z-index: 2;
     display: inline;
     .content {

--- a/mapstory/templates/viewer/story_viewer.html
+++ b/mapstory/templates/viewer/story_viewer.html
@@ -24,7 +24,10 @@
                 {% endif %}
             </a>
             <i class="fa fa-caret-left" ng-click="toggleSidebar()"></i>
-            <i class="fa fa-caret-right" ng-click="toggleSidebar()"></i>
+            <div class="expand-button">
+                <p>Story Info</p>
+                <i class="fa fa-caret-right" ng-click="toggleSidebar()"></i>
+            </div>
         </div>
         <div class="content">
             {% verbatim %}


### PR DESCRIPTION
This closes #310.

With changes, collapsed sidebar now looks like this for stories:
![screen shot 2017-04-24 at 4 48 32 pm](https://cloud.githubusercontent.com/assets/1529366/25360306/370c8382-290e-11e7-8926-bb3850ecab2f.png)