### PR TITLE
Update Bower Packages Every Provision

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -134,6 +134,7 @@ def collect():
         with cd('/srv/git/mapstory/mapstory/mapstory/static'):
             run('npm install')
             run('bower install --noinput')
+            run('bower update --noinput')
             sudo('grunt less', user='mapstory')
             sudo('grunt copy', user='mapstory')
 

--- a/scripts/provision/roles/web/tasks/mapstory.yml
+++ b/scripts/provision/roles/web/tasks/mapstory.yml
@@ -226,6 +226,13 @@
   become_user: '{{ application_user }}'
   tags: [update]
 
+- name: mapstory bower update
+  shell: bower update
+  args:
+    chdir: '{{ project_path }}/mapstory/static'
+  become_user: '{{ application_user }}'
+  tags: [update]
+
 - name: collect-static local
   django_manage: app_path={{ project_path }} virtualenv={{ venv }} command='collectstatic --link --noinput --ignore node_modules'
   become_user: '{{ application_user }}'
@@ -233,7 +240,6 @@
   tags: [update, reload]
   ignore_errors: True
   tags: [update]
-
 
 - name: reload indexes
   django_manage: app_path={{ project_path }} virtualenv={{ venv }} command='rebuild_index --noinput'


### PR DESCRIPTION
Our bower packages (mostly story-tools) were not always being updated to the latest version which was causing issues when we expected story-tools to be up to date.  This solution should fix that issue during provisioning, and I’ve also added it to the fab dev collect task in case a developer wants to run it without a provision.