### PR TITLE
Restoring regions fixture to our provision process

### DIFF
--- a/mapstory/fixtures/initial_data.json
+++ b/mapstory/fixtures/initial_data.json
@@ -94,5 +94,3372 @@
             "gn_description": "Biography",
             "identifier": "biography"
         }
+    },
+     {
+    "pk": 1,
+    "model": "base.region",
+    "fields": {
+      "rght": 516,
+      "code": "GLO",
+      "name": "Global",
+      "parent": null,
+      "level": 0,
+      "lft": 1,
+      "tree_id": 90
     }
+  },
+  {
+    "pk": 2,
+    "model": "base.region",
+    "fields": {
+      "rght": 212,
+      "code": "NAM",
+      "name": "North America",
+      "parent": 254,
+      "level": 2,
+      "lft": 203,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 3,
+    "model": "base.region",
+    "fields": {
+      "rght": 202,
+      "code": "CAM",
+      "name": "Central America",
+      "parent": 254,
+      "level": 2,
+      "lft": 187,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 4,
+    "model": "base.region",
+    "fields": {
+      "rght": 242,
+      "code": "SAM",
+      "name": "South America",
+      "parent": 254,
+      "level": 2,
+      "lft": 213,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 5,
+    "model": "base.region",
+    "fields": {
+      "rght": 433,
+      "code": "EUR",
+      "name": "Europe",
+      "parent": 1,
+      "level": 1,
+      "lft": 318,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 6,
+    "model": "base.region",
+    "fields": {
+      "rght": 317,
+      "code": "ASI",
+      "name": "Asia",
+      "parent": 1,
+      "level": 1,
+      "lft": 246,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 7,
+    "model": "base.region",
+    "fields": {
+      "rght": 316,
+      "code": "SEA",
+      "name": "Southeast Asia",
+      "parent": 6,
+      "level": 2,
+      "lft": 293,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 8,
+    "model": "base.region",
+    "fields": {
+      "rght": 260,
+      "code": "CTA",
+      "name": "Central Asia",
+      "parent": 6,
+      "level": 2,
+      "lft": 247,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 9,
+    "model": "base.region",
+    "fields": {
+      "rght": 292,
+      "code": "SAS",
+      "name": "South Asia",
+      "parent": 6,
+      "level": 2,
+      "lft": 277,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 10,
+    "model": "base.region",
+    "fields": {
+      "rght": 127,
+      "code": "AFR",
+      "name": "Africa",
+      "parent": 1,
+      "level": 1,
+      "lft": 2,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 11,
+    "model": "base.region",
+    "fields": {
+      "rght": 64,
+      "code": "NAF",
+      "name": "North Africa",
+      "parent": 10,
+      "level": 2,
+      "lft": 49,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 12,
+    "model": "base.region",
+    "fields": {
+      "rght": 48,
+      "code": "EAF",
+      "name": "East Africa",
+      "parent": 10,
+      "level": 2,
+      "lft": 13,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 13,
+    "model": "base.region",
+    "fields": {
+      "rght": 126,
+      "code": "WAF",
+      "name": "West Africa",
+      "parent": 10,
+      "level": 2,
+      "lft": 83,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 14,
+    "model": "base.region",
+    "fields": {
+      "rght": 82,
+      "code": "SAF",
+      "name": "Southern Africa",
+      "parent": 10,
+      "level": 2,
+      "lft": 65,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 15,
+    "model": "base.region",
+    "fields": {
+      "rght": 463,
+      "code": "MES",
+      "name": "Middle East",
+      "parent": 1,
+      "level": 1,
+      "lft": 434,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 16,
+    "model": "base.region",
+    "fields": {
+      "rght": 245,
+      "code": "ANT",
+      "name": "Antarctica",
+      "parent": 1,
+      "level": 1,
+      "lft": 244,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 17,
+    "model": "base.region",
+    "fields": {
+      "rght": 249,
+      "code": "AFG",
+      "name": "Afghanistan",
+      "parent": 8,
+      "level": 3,
+      "lft": 248,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 18,
+    "model": "base.region",
+    "fields": {
+      "rght": 320,
+      "code": "ALA",
+      "name": "Aland Islands",
+      "parent": 5,
+      "level": 2,
+      "lft": 319,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 19,
+    "model": "base.region",
+    "fields": {
+      "rght": 322,
+      "code": "ALB",
+      "name": "Albania",
+      "parent": 5,
+      "level": 2,
+      "lft": 321,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 20,
+    "model": "base.region",
+    "fields": {
+      "rght": 51,
+      "code": "DZA",
+      "name": "Algeria",
+      "parent": 11,
+      "level": 3,
+      "lft": 50,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 21,
+    "model": "base.region",
+    "fields": {
+      "rght": 466,
+      "code": "ASM",
+      "name": "American Samoa",
+      "parent": 256,
+      "level": 2,
+      "lft": 465,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 22,
+    "model": "base.region",
+    "fields": {
+      "rght": 324,
+      "code": "AND",
+      "name": "Andorra",
+      "parent": 5,
+      "level": 2,
+      "lft": 323,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 23,
+    "model": "base.region",
+    "fields": {
+      "rght": 85,
+      "code": "AGO",
+      "name": "Angola",
+      "parent": 13,
+      "level": 3,
+      "lft": 84,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 24,
+    "model": "base.region",
+    "fields": {
+      "rght": 131,
+      "code": "AIA",
+      "name": "Anguilla",
+      "parent": 255,
+      "level": 3,
+      "lft": 130,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 25,
+    "model": "base.region",
+    "fields": {
+      "rght": 133,
+      "code": "ATG",
+      "name": "Antigua and Barbuda",
+      "parent": 255,
+      "level": 3,
+      "lft": 132,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 26,
+    "model": "base.region",
+    "fields": {
+      "rght": 215,
+      "code": "ARG",
+      "name": "Argentina",
+      "parent": 4,
+      "level": 3,
+      "lft": 214,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 27,
+    "model": "base.region",
+    "fields": {
+      "rght": 326,
+      "code": "ARM",
+      "name": "Armenia",
+      "parent": 5,
+      "level": 2,
+      "lft": 325,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 28,
+    "model": "base.region",
+    "fields": {
+      "rght": 135,
+      "code": "ABW",
+      "name": "Aruba",
+      "parent": 255,
+      "level": 3,
+      "lft": 134,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 29,
+    "model": "base.region",
+    "fields": {
+      "rght": 468,
+      "code": "AUS",
+      "name": "Australia",
+      "parent": 256,
+      "level": 2,
+      "lft": 467,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 30,
+    "model": "base.region",
+    "fields": {
+      "rght": 328,
+      "code": "AUT",
+      "name": "Austria",
+      "parent": 5,
+      "level": 2,
+      "lft": 327,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 31,
+    "model": "base.region",
+    "fields": {
+      "rght": 330,
+      "code": "AZE",
+      "name": "Azerbaijan",
+      "parent": 5,
+      "level": 2,
+      "lft": 329,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 32,
+    "model": "base.region",
+    "fields": {
+      "rght": 137,
+      "code": "BHS",
+      "name": "Bahamas",
+      "parent": 255,
+      "level": 3,
+      "lft": 136,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 33,
+    "model": "base.region",
+    "fields": {
+      "rght": 436,
+      "code": "BHR",
+      "name": "Bahrain",
+      "parent": 15,
+      "level": 2,
+      "lft": 435,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 34,
+    "model": "base.region",
+    "fields": {
+      "rght": 279,
+      "code": "BGD",
+      "name": "Bangladesh",
+      "parent": 9,
+      "level": 3,
+      "lft": 278,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 35,
+    "model": "base.region",
+    "fields": {
+      "rght": 139,
+      "code": "BRB",
+      "name": "Barbados",
+      "parent": 255,
+      "level": 3,
+      "lft": 138,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 36,
+    "model": "base.region",
+    "fields": {
+      "rght": 332,
+      "code": "BLR",
+      "name": "Belarus",
+      "parent": 5,
+      "level": 2,
+      "lft": 331,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 37,
+    "model": "base.region",
+    "fields": {
+      "rght": 334,
+      "code": "BEL",
+      "name": "Belgium",
+      "parent": 5,
+      "level": 2,
+      "lft": 333,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 38,
+    "model": "base.region",
+    "fields": {
+      "rght": 189,
+      "code": "BLZ",
+      "name": "Belize",
+      "parent": 3,
+      "level": 3,
+      "lft": 188,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 39,
+    "model": "base.region",
+    "fields": {
+      "rght": 87,
+      "code": "BEN",
+      "name": "Benin",
+      "parent": 13,
+      "level": 3,
+      "lft": 86,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 40,
+    "model": "base.region",
+    "fields": {
+      "rght": 141,
+      "code": "BMU",
+      "name": "Bermuda",
+      "parent": 255,
+      "level": 3,
+      "lft": 140,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 41,
+    "model": "base.region",
+    "fields": {
+      "rght": 281,
+      "code": "BTN",
+      "name": "Bhutan",
+      "parent": 9,
+      "level": 3,
+      "lft": 280,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 42,
+    "model": "base.region",
+    "fields": {
+      "rght": 217,
+      "code": "BOL",
+      "name": "Bolivia",
+      "parent": 4,
+      "level": 3,
+      "lft": 216,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 43,
+    "model": "base.region",
+    "fields": {
+      "rght": 336,
+      "code": "BIH",
+      "name": "Bosnia and Herzegovina",
+      "parent": 5,
+      "level": 2,
+      "lft": 335,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 44,
+    "model": "base.region",
+    "fields": {
+      "rght": 67,
+      "code": "BWA",
+      "name": "Botswana",
+      "parent": 14,
+      "level": 3,
+      "lft": 66,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 45,
+    "model": "base.region",
+    "fields": {
+      "rght": 219,
+      "code": "BRA",
+      "name": "Brazil",
+      "parent": 4,
+      "level": 3,
+      "lft": 218,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 46,
+    "model": "base.region",
+    "fields": {
+      "rght": 143,
+      "code": "VGB",
+      "name": "British Virgin Islands",
+      "parent": 255,
+      "level": 3,
+      "lft": 142,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 47,
+    "model": "base.region",
+    "fields": {
+      "rght": 295,
+      "code": "BRN",
+      "name": "Brunei Darussalam",
+      "parent": 7,
+      "level": 3,
+      "lft": 294,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 48,
+    "model": "base.region",
+    "fields": {
+      "rght": 338,
+      "code": "BGR",
+      "name": "Bulgaria",
+      "parent": 5,
+      "level": 2,
+      "lft": 337,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 49,
+    "model": "base.region",
+    "fields": {
+      "rght": 89,
+      "code": "BFA",
+      "name": "Burkina Faso",
+      "parent": 13,
+      "level": 3,
+      "lft": 88,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 50,
+    "model": "base.region",
+    "fields": {
+      "rght": 15,
+      "code": "BDI",
+      "name": "Burundi",
+      "parent": 12,
+      "level": 3,
+      "lft": 14,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 51,
+    "model": "base.region",
+    "fields": {
+      "rght": 297,
+      "code": "KHM",
+      "name": "Cambodia",
+      "parent": 7,
+      "level": 3,
+      "lft": 296,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 52,
+    "model": "base.region",
+    "fields": {
+      "rght": 91,
+      "code": "CMR",
+      "name": "Cameroon",
+      "parent": 13,
+      "level": 3,
+      "lft": 90,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 53,
+    "model": "base.region",
+    "fields": {
+      "rght": 205,
+      "code": "CAN",
+      "name": "Canada",
+      "parent": 2,
+      "level": 3,
+      "lft": 204,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 54,
+    "model": "base.region",
+    "fields": {
+      "rght": 93,
+      "code": "CPV",
+      "name": "Cape Verde",
+      "parent": 13,
+      "level": 3,
+      "lft": 92,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 55,
+    "model": "base.region",
+    "fields": {
+      "rght": 145,
+      "code": "CYM",
+      "name": "Cayman Islands",
+      "parent": 255,
+      "level": 3,
+      "lft": 144,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 56,
+    "model": "base.region",
+    "fields": {
+      "rght": 5,
+      "code": "CAF",
+      "name": "Central African Republic",
+      "parent": 257,
+      "level": 3,
+      "lft": 4,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 57,
+    "model": "base.region",
+    "fields": {
+      "rght": 7,
+      "code": "TCD",
+      "name": "Chad",
+      "parent": 257,
+      "level": 3,
+      "lft": 6,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 58,
+    "model": "base.region",
+    "fields": {
+      "rght": 340,
+      "code": "CIL",
+      "name": "Channel Islands",
+      "parent": 5,
+      "level": 2,
+      "lft": 339,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 59,
+    "model": "base.region",
+    "fields": {
+      "rght": 221,
+      "code": "CHL",
+      "name": "Chile",
+      "parent": 4,
+      "level": 3,
+      "lft": 220,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 60,
+    "model": "base.region",
+    "fields": {
+      "rght": 263,
+      "code": "CHN",
+      "name": "China",
+      "parent": 258,
+      "level": 3,
+      "lft": 262,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 61,
+    "model": "base.region",
+    "fields": {
+      "rght": 265,
+      "code": "HKG",
+      "name": "China - Hong Kong",
+      "parent": 258,
+      "level": 3,
+      "lft": 264,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 62,
+    "model": "base.region",
+    "fields": {
+      "rght": 267,
+      "code": "MAC",
+      "name": "China - Macao",
+      "parent": 258,
+      "level": 3,
+      "lft": 266,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 63,
+    "model": "base.region",
+    "fields": {
+      "rght": 223,
+      "code": "COL",
+      "name": "Colombia",
+      "parent": 4,
+      "level": 3,
+      "lft": 222,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 64,
+    "model": "base.region",
+    "fields": {
+      "rght": 17,
+      "code": "COM",
+      "name": "Comoros",
+      "parent": 12,
+      "level": 3,
+      "lft": 16,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 65,
+    "model": "base.region",
+    "fields": {
+      "rght": 9,
+      "code": "COG",
+      "name": "Congo",
+      "parent": 257,
+      "level": 3,
+      "lft": 8,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 66,
+    "model": "base.region",
+    "fields": {
+      "rght": 470,
+      "code": "COK",
+      "name": "Cook Islands",
+      "parent": 256,
+      "level": 2,
+      "lft": 469,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 67,
+    "model": "base.region",
+    "fields": {
+      "rght": 191,
+      "code": "CRI",
+      "name": "Costa Rica",
+      "parent": 3,
+      "level": 3,
+      "lft": 190,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 68,
+    "model": "base.region",
+    "fields": {
+      "rght": 95,
+      "code": "CIV",
+      "name": "Cote d'Ivoire",
+      "parent": 13,
+      "level": 3,
+      "lft": 94,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 69,
+    "model": "base.region",
+    "fields": {
+      "rght": 342,
+      "code": "HRV",
+      "name": "Croatia",
+      "parent": 5,
+      "level": 2,
+      "lft": 341,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 70,
+    "model": "base.region",
+    "fields": {
+      "rght": 147,
+      "code": "CUB",
+      "name": "Cuba",
+      "parent": 255,
+      "level": 3,
+      "lft": 146,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 71,
+    "model": "base.region",
+    "fields": {
+      "rght": 344,
+      "code": "CYP",
+      "name": "Cyprus",
+      "parent": 5,
+      "level": 2,
+      "lft": 343,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 72,
+    "model": "base.region",
+    "fields": {
+      "rght": 346,
+      "code": "CZE",
+      "name": "Czech Republic",
+      "parent": 5,
+      "level": 2,
+      "lft": 345,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 73,
+    "model": "base.region",
+    "fields": {
+      "rght": 269,
+      "code": "PRK",
+      "name": "Democratic People's Republic of Korea",
+      "parent": 258,
+      "level": 3,
+      "lft": 268,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 74,
+    "model": "base.region",
+    "fields": {
+      "rght": 11,
+      "code": "COD",
+      "name": "Democratic Republic of the Congo",
+      "parent": 257,
+      "level": 3,
+      "lft": 10,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 75,
+    "model": "base.region",
+    "fields": {
+      "rght": 348,
+      "code": "DNK",
+      "name": "Denmark",
+      "parent": 5,
+      "level": 2,
+      "lft": 347,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 76,
+    "model": "base.region",
+    "fields": {
+      "rght": 19,
+      "code": "DJI",
+      "name": "Djibouti",
+      "parent": 12,
+      "level": 3,
+      "lft": 18,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 77,
+    "model": "base.region",
+    "fields": {
+      "rght": 149,
+      "code": "DMA",
+      "name": "Dominica",
+      "parent": 255,
+      "level": 3,
+      "lft": 148,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 78,
+    "model": "base.region",
+    "fields": {
+      "rght": 151,
+      "code": "DOM",
+      "name": "Dominican Republic",
+      "parent": 255,
+      "level": 3,
+      "lft": 150,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 79,
+    "model": "base.region",
+    "fields": {
+      "rght": 225,
+      "code": "ECU",
+      "name": "Ecuador",
+      "parent": 4,
+      "level": 3,
+      "lft": 224,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 80,
+    "model": "base.region",
+    "fields": {
+      "rght": 53,
+      "code": "EGY",
+      "name": "Egypt",
+      "parent": 11,
+      "level": 3,
+      "lft": 52,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 81,
+    "model": "base.region",
+    "fields": {
+      "rght": 193,
+      "code": "SLV",
+      "name": "El Salvador",
+      "parent": 3,
+      "level": 3,
+      "lft": 192,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 82,
+    "model": "base.region",
+    "fields": {
+      "rght": 97,
+      "code": "GNQ",
+      "name": "Equatorial Guinea",
+      "parent": 13,
+      "level": 3,
+      "lft": 96,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 83,
+    "model": "base.region",
+    "fields": {
+      "rght": 21,
+      "code": "ERI",
+      "name": "Eritrea",
+      "parent": 12,
+      "level": 3,
+      "lft": 20,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 84,
+    "model": "base.region",
+    "fields": {
+      "rght": 350,
+      "code": "EST",
+      "name": "Estonia",
+      "parent": 5,
+      "level": 2,
+      "lft": 349,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 85,
+    "model": "base.region",
+    "fields": {
+      "rght": 23,
+      "code": "ETH",
+      "name": "Ethiopia",
+      "parent": 12,
+      "level": 3,
+      "lft": 22,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 86,
+    "model": "base.region",
+    "fields": {
+      "rght": 352,
+      "code": "FRO",
+      "name": "Faeroe Islands",
+      "parent": 5,
+      "level": 2,
+      "lft": 351,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 87,
+    "model": "base.region",
+    "fields": {
+      "rght": 227,
+      "code": "FLK",
+      "name": "Falkland Islands (Malvinas)",
+      "parent": 4,
+      "level": 3,
+      "lft": 226,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 88,
+    "model": "base.region",
+    "fields": {
+      "rght": 472,
+      "code": "FJI",
+      "name": "Fiji",
+      "parent": 256,
+      "level": 2,
+      "lft": 471,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 89,
+    "model": "base.region",
+    "fields": {
+      "rght": 354,
+      "code": "FIN",
+      "name": "Finland",
+      "parent": 5,
+      "level": 2,
+      "lft": 353,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 90,
+    "model": "base.region",
+    "fields": {
+      "rght": 356,
+      "code": "FRA",
+      "name": "France",
+      "parent": 5,
+      "level": 2,
+      "lft": 355,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 91,
+    "model": "base.region",
+    "fields": {
+      "rght": 229,
+      "code": "GUF",
+      "name": "French Guiana",
+      "parent": 4,
+      "level": 3,
+      "lft": 228,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 92,
+    "model": "base.region",
+    "fields": {
+      "rght": 474,
+      "code": "PYF",
+      "name": "French Polynesia",
+      "parent": 256,
+      "level": 2,
+      "lft": 473,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 93,
+    "model": "base.region",
+    "fields": {
+      "rght": 99,
+      "code": "GAB",
+      "name": "Gabon",
+      "parent": 13,
+      "level": 3,
+      "lft": 98,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 94,
+    "model": "base.region",
+    "fields": {
+      "rght": 101,
+      "code": "GMB",
+      "name": "Gambia",
+      "parent": 13,
+      "level": 3,
+      "lft": 100,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 95,
+    "model": "base.region",
+    "fields": {
+      "rght": 358,
+      "code": "GEO",
+      "name": "Georgia",
+      "parent": 5,
+      "level": 2,
+      "lft": 357,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 96,
+    "model": "base.region",
+    "fields": {
+      "rght": 360,
+      "code": "DEU",
+      "name": "Germany",
+      "parent": 5,
+      "level": 2,
+      "lft": 359,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 97,
+    "model": "base.region",
+    "fields": {
+      "rght": 103,
+      "code": "GHA",
+      "name": "Ghana",
+      "parent": 13,
+      "level": 3,
+      "lft": 102,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 98,
+    "model": "base.region",
+    "fields": {
+      "rght": 362,
+      "code": "GIB",
+      "name": "Gibraltar",
+      "parent": 5,
+      "level": 2,
+      "lft": 361,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 99,
+    "model": "base.region",
+    "fields": {
+      "rght": 364,
+      "code": "GRC",
+      "name": "Greece",
+      "parent": 5,
+      "level": 2,
+      "lft": 363,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 100,
+    "model": "base.region",
+    "fields": {
+      "rght": 207,
+      "code": "GRL",
+      "name": "Greenland",
+      "parent": 2,
+      "level": 3,
+      "lft": 206,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 101,
+    "model": "base.region",
+    "fields": {
+      "rght": 153,
+      "code": "GRD",
+      "name": "Grenada",
+      "parent": 255,
+      "level": 3,
+      "lft": 152,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 102,
+    "model": "base.region",
+    "fields": {
+      "rght": 155,
+      "code": "GLP",
+      "name": "Guadeloupe",
+      "parent": 255,
+      "level": 3,
+      "lft": 154,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 103,
+    "model": "base.region",
+    "fields": {
+      "rght": 476,
+      "code": "GUM",
+      "name": "Guam",
+      "parent": 256,
+      "level": 2,
+      "lft": 475,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 104,
+    "model": "base.region",
+    "fields": {
+      "rght": 195,
+      "code": "GTM",
+      "name": "Guatemala",
+      "parent": 3,
+      "level": 3,
+      "lft": 194,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 105,
+    "model": "base.region",
+    "fields": {
+      "rght": 366,
+      "code": "GGY",
+      "name": "Guernsey",
+      "parent": 5,
+      "level": 2,
+      "lft": 365,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 106,
+    "model": "base.region",
+    "fields": {
+      "rght": 105,
+      "code": "GIN",
+      "name": "Guinea",
+      "parent": 13,
+      "level": 3,
+      "lft": 104,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 107,
+    "model": "base.region",
+    "fields": {
+      "rght": 107,
+      "code": "GNB",
+      "name": "Guinea-Bissau",
+      "parent": 13,
+      "level": 3,
+      "lft": 106,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 108,
+    "model": "base.region",
+    "fields": {
+      "rght": 231,
+      "code": "GUY",
+      "name": "Guyana",
+      "parent": 4,
+      "level": 3,
+      "lft": 230,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 109,
+    "model": "base.region",
+    "fields": {
+      "rght": 157,
+      "code": "HTI",
+      "name": "Haiti",
+      "parent": 255,
+      "level": 3,
+      "lft": 156,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 110,
+    "model": "base.region",
+    "fields": {
+      "rght": 368,
+      "code": "VAT",
+      "name": "Holy See (Vatican City)",
+      "parent": 5,
+      "level": 2,
+      "lft": 367,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 111,
+    "model": "base.region",
+    "fields": {
+      "rght": 197,
+      "code": "HND",
+      "name": "Honduras",
+      "parent": 3,
+      "level": 3,
+      "lft": 196,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 112,
+    "model": "base.region",
+    "fields": {
+      "rght": 370,
+      "code": "HUN",
+      "name": "Hungary",
+      "parent": 5,
+      "level": 2,
+      "lft": 369,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 113,
+    "model": "base.region",
+    "fields": {
+      "rght": 372,
+      "code": "ISL",
+      "name": "Iceland",
+      "parent": 5,
+      "level": 2,
+      "lft": 371,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 114,
+    "model": "base.region",
+    "fields": {
+      "rght": 283,
+      "code": "IND",
+      "name": "India",
+      "parent": 9,
+      "level": 3,
+      "lft": 282,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 115,
+    "model": "base.region",
+    "fields": {
+      "rght": 299,
+      "code": "IDN",
+      "name": "Indonesia",
+      "parent": 7,
+      "level": 3,
+      "lft": 298,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 116,
+    "model": "base.region",
+    "fields": {
+      "rght": 438,
+      "code": "IRN",
+      "name": "Iran",
+      "parent": 15,
+      "level": 2,
+      "lft": 437,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 117,
+    "model": "base.region",
+    "fields": {
+      "rght": 440,
+      "code": "IRQ",
+      "name": "Iraq",
+      "parent": 15,
+      "level": 2,
+      "lft": 439,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 118,
+    "model": "base.region",
+    "fields": {
+      "rght": 374,
+      "code": "IRL",
+      "name": "Ireland",
+      "parent": 5,
+      "level": 2,
+      "lft": 373,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 119,
+    "model": "base.region",
+    "fields": {
+      "rght": 376,
+      "code": "IMN",
+      "name": "Isle of Man",
+      "parent": 5,
+      "level": 2,
+      "lft": 375,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 120,
+    "model": "base.region",
+    "fields": {
+      "rght": 442,
+      "code": "ISR",
+      "name": "Israel",
+      "parent": 15,
+      "level": 2,
+      "lft": 441,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 121,
+    "model": "base.region",
+    "fields": {
+      "rght": 378,
+      "code": "ITA",
+      "name": "Italy",
+      "parent": 5,
+      "level": 2,
+      "lft": 377,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 122,
+    "model": "base.region",
+    "fields": {
+      "rght": 159,
+      "code": "JAM",
+      "name": "Jamaica",
+      "parent": 255,
+      "level": 3,
+      "lft": 158,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 123,
+    "model": "base.region",
+    "fields": {
+      "rght": 271,
+      "code": "JPN",
+      "name": "Japan",
+      "parent": 258,
+      "level": 3,
+      "lft": 270,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 124,
+    "model": "base.region",
+    "fields": {
+      "rght": 380,
+      "code": "JEY",
+      "name": "Jersey",
+      "parent": 5,
+      "level": 2,
+      "lft": 379,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 125,
+    "model": "base.region",
+    "fields": {
+      "rght": 444,
+      "code": "JOR",
+      "name": "Jordan",
+      "parent": 15,
+      "level": 2,
+      "lft": 443,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 126,
+    "model": "base.region",
+    "fields": {
+      "rght": 251,
+      "code": "KAZ",
+      "name": "Kazakhstan",
+      "parent": 8,
+      "level": 3,
+      "lft": 250,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 127,
+    "model": "base.region",
+    "fields": {
+      "rght": 25,
+      "code": "KEN",
+      "name": "Kenya",
+      "parent": 12,
+      "level": 3,
+      "lft": 24,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 128,
+    "model": "base.region",
+    "fields": {
+      "rght": 478,
+      "code": "KIR",
+      "name": "Kiribati",
+      "parent": 256,
+      "level": 2,
+      "lft": 477,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 129,
+    "model": "base.region",
+    "fields": {
+      "rght": 446,
+      "code": "KWT",
+      "name": "Kuwait",
+      "parent": 15,
+      "level": 2,
+      "lft": 445,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 130,
+    "model": "base.region",
+    "fields": {
+      "rght": 253,
+      "code": "KGZ",
+      "name": "Kyrgyzstan",
+      "parent": 8,
+      "level": 3,
+      "lft": 252,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 131,
+    "model": "base.region",
+    "fields": {
+      "rght": 301,
+      "code": "LAO",
+      "name": "Lao People's Democratic Republic",
+      "parent": 7,
+      "level": 3,
+      "lft": 300,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 132,
+    "model": "base.region",
+    "fields": {
+      "rght": 382,
+      "code": "LVA",
+      "name": "Latvia",
+      "parent": 5,
+      "level": 2,
+      "lft": 381,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 133,
+    "model": "base.region",
+    "fields": {
+      "rght": 448,
+      "code": "LBN",
+      "name": "Lebanon",
+      "parent": 15,
+      "level": 2,
+      "lft": 447,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 134,
+    "model": "base.region",
+    "fields": {
+      "rght": 69,
+      "code": "LSO",
+      "name": "Lesotho",
+      "parent": 14,
+      "level": 3,
+      "lft": 68,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 135,
+    "model": "base.region",
+    "fields": {
+      "rght": 109,
+      "code": "LBR",
+      "name": "Liberia",
+      "parent": 13,
+      "level": 3,
+      "lft": 108,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 136,
+    "model": "base.region",
+    "fields": {
+      "rght": 55,
+      "code": "LBY",
+      "name": "Libyan Arab Jamahiriya",
+      "parent": 11,
+      "level": 3,
+      "lft": 54,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 137,
+    "model": "base.region",
+    "fields": {
+      "rght": 384,
+      "code": "LIE",
+      "name": "Liechtenstein",
+      "parent": 5,
+      "level": 2,
+      "lft": 383,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 138,
+    "model": "base.region",
+    "fields": {
+      "rght": 386,
+      "code": "LTU",
+      "name": "Lithuania",
+      "parent": 5,
+      "level": 2,
+      "lft": 385,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 139,
+    "model": "base.region",
+    "fields": {
+      "rght": 388,
+      "code": "LUX",
+      "name": "Luxembourg",
+      "parent": 5,
+      "level": 2,
+      "lft": 387,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 140,
+    "model": "base.region",
+    "fields": {
+      "rght": 390,
+      "code": "MKD",
+      "name": "Macedonia",
+      "parent": 5,
+      "level": 2,
+      "lft": 389,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 141,
+    "model": "base.region",
+    "fields": {
+      "rght": 27,
+      "code": "MDG",
+      "name": "Madagascar",
+      "parent": 12,
+      "level": 3,
+      "lft": 26,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 142,
+    "model": "base.region",
+    "fields": {
+      "rght": 29,
+      "code": "MWI",
+      "name": "Malawi",
+      "parent": 12,
+      "level": 3,
+      "lft": 28,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 143,
+    "model": "base.region",
+    "fields": {
+      "rght": 303,
+      "code": "MYS",
+      "name": "Malaysia",
+      "parent": 7,
+      "level": 3,
+      "lft": 302,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 144,
+    "model": "base.region",
+    "fields": {
+      "rght": 285,
+      "code": "MDV",
+      "name": "Maldives",
+      "parent": 9,
+      "level": 3,
+      "lft": 284,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 145,
+    "model": "base.region",
+    "fields": {
+      "rght": 111,
+      "code": "MLI",
+      "name": "Mali",
+      "parent": 13,
+      "level": 3,
+      "lft": 110,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 146,
+    "model": "base.region",
+    "fields": {
+      "rght": 392,
+      "code": "MLT",
+      "name": "Malta",
+      "parent": 5,
+      "level": 2,
+      "lft": 391,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 147,
+    "model": "base.region",
+    "fields": {
+      "rght": 480,
+      "code": "MHL",
+      "name": "Marshall Islands",
+      "parent": 256,
+      "level": 2,
+      "lft": 479,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 148,
+    "model": "base.region",
+    "fields": {
+      "rght": 161,
+      "code": "MTQ",
+      "name": "Martinique",
+      "parent": 255,
+      "level": 3,
+      "lft": 160,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 149,
+    "model": "base.region",
+    "fields": {
+      "rght": 113,
+      "code": "MRT",
+      "name": "Mauritania",
+      "parent": 13,
+      "level": 3,
+      "lft": 112,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 150,
+    "model": "base.region",
+    "fields": {
+      "rght": 31,
+      "code": "MUS",
+      "name": "Mauritius",
+      "parent": 12,
+      "level": 3,
+      "lft": 30,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 151,
+    "model": "base.region",
+    "fields": {
+      "rght": 33,
+      "code": "MYT",
+      "name": "Mayotte",
+      "parent": 12,
+      "level": 3,
+      "lft": 32,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 152,
+    "model": "base.region",
+    "fields": {
+      "rght": 209,
+      "code": "MEX",
+      "name": "Mexico",
+      "parent": 2,
+      "level": 3,
+      "lft": 208,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 153,
+    "model": "base.region",
+    "fields": {
+      "rght": 482,
+      "code": "FSM",
+      "name": "Micronesia, Federated States of",
+      "parent": 256,
+      "level": 2,
+      "lft": 481,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 154,
+    "model": "base.region",
+    "fields": {
+      "rght": 394,
+      "code": "MCO",
+      "name": "Monaco",
+      "parent": 5,
+      "level": 2,
+      "lft": 393,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 155,
+    "model": "base.region",
+    "fields": {
+      "rght": 273,
+      "code": "MNG",
+      "name": "Mongolia",
+      "parent": 258,
+      "level": 3,
+      "lft": 272,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 156,
+    "model": "base.region",
+    "fields": {
+      "rght": 396,
+      "code": "MNE",
+      "name": "Montenegro",
+      "parent": 5,
+      "level": 2,
+      "lft": 395,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 157,
+    "model": "base.region",
+    "fields": {
+      "rght": 163,
+      "code": "MSR",
+      "name": "Montserrat",
+      "parent": 255,
+      "level": 3,
+      "lft": 162,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 158,
+    "model": "base.region",
+    "fields": {
+      "rght": 57,
+      "code": "MAR",
+      "name": "Morocco",
+      "parent": 11,
+      "level": 3,
+      "lft": 56,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 159,
+    "model": "base.region",
+    "fields": {
+      "rght": 35,
+      "code": "MOZ",
+      "name": "Mozambique",
+      "parent": 12,
+      "level": 3,
+      "lft": 34,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 160,
+    "model": "base.region",
+    "fields": {
+      "rght": 305,
+      "code": "MMR",
+      "name": "Myanmar",
+      "parent": 7,
+      "level": 3,
+      "lft": 304,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 161,
+    "model": "base.region",
+    "fields": {
+      "rght": 71,
+      "code": "NMB",
+      "name": "Namibia",
+      "parent": 14,
+      "level": 3,
+      "lft": 70,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 162,
+    "model": "base.region",
+    "fields": {
+      "rght": 484,
+      "code": "NRU",
+      "name": "Nauru",
+      "parent": 256,
+      "level": 2,
+      "lft": 483,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 163,
+    "model": "base.region",
+    "fields": {
+      "rght": 287,
+      "code": "NPL",
+      "name": "Nepal",
+      "parent": 9,
+      "level": 3,
+      "lft": 286,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 164,
+    "model": "base.region",
+    "fields": {
+      "rght": 398,
+      "code": "NLD",
+      "name": "Netherlands",
+      "parent": 5,
+      "level": 2,
+      "lft": 397,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 165,
+    "model": "base.region",
+    "fields": {
+      "rght": 165,
+      "code": "NAN",
+      "name": "Netherlands Antilles",
+      "parent": 255,
+      "level": 3,
+      "lft": 164,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 166,
+    "model": "base.region",
+    "fields": {
+      "rght": 486,
+      "code": "NCL",
+      "name": "New Caledonia",
+      "parent": 256,
+      "level": 2,
+      "lft": 485,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 167,
+    "model": "base.region",
+    "fields": {
+      "rght": 488,
+      "code": "NZL",
+      "name": "New Zealand",
+      "parent": 256,
+      "level": 2,
+      "lft": 487,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 168,
+    "model": "base.region",
+    "fields": {
+      "rght": 199,
+      "code": "NIC",
+      "name": "Nicaragua",
+      "parent": 3,
+      "level": 3,
+      "lft": 198,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 169,
+    "model": "base.region",
+    "fields": {
+      "rght": 115,
+      "code": "NER",
+      "name": "Niger",
+      "parent": 13,
+      "level": 3,
+      "lft": 114,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 170,
+    "model": "base.region",
+    "fields": {
+      "rght": 117,
+      "code": "NGA",
+      "name": "Nigeria",
+      "parent": 13,
+      "level": 3,
+      "lft": 116,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 171,
+    "model": "base.region",
+    "fields": {
+      "rght": 490,
+      "code": "NIU",
+      "name": "Niue",
+      "parent": 256,
+      "level": 2,
+      "lft": 489,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 172,
+    "model": "base.region",
+    "fields": {
+      "rght": 492,
+      "code": "NFK",
+      "name": "Norfolk Island",
+      "parent": 256,
+      "level": 2,
+      "lft": 491,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 173,
+    "model": "base.region",
+    "fields": {
+      "rght": 494,
+      "code": "MNP",
+      "name": "Northern Mariana Islands",
+      "parent": 256,
+      "level": 2,
+      "lft": 493,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 174,
+    "model": "base.region",
+    "fields": {
+      "rght": 400,
+      "code": "NOR",
+      "name": "Norway",
+      "parent": 5,
+      "level": 2,
+      "lft": 399,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 175,
+    "model": "base.region",
+    "fields": {
+      "rght": 450,
+      "code": "PSE",
+      "name": "Occupied Palestinian Territory",
+      "parent": 15,
+      "level": 2,
+      "lft": 449,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 176,
+    "model": "base.region",
+    "fields": {
+      "rght": 452,
+      "code": "OMN",
+      "name": "Oman",
+      "parent": 15,
+      "level": 2,
+      "lft": 451,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 177,
+    "model": "base.region",
+    "fields": {
+      "rght": 289,
+      "code": "PAK",
+      "name": "Pakistan",
+      "parent": 9,
+      "level": 3,
+      "lft": 288,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 178,
+    "model": "base.region",
+    "fields": {
+      "rght": 496,
+      "code": "PLW",
+      "name": "Palau",
+      "parent": 256,
+      "level": 2,
+      "lft": 495,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 179,
+    "model": "base.region",
+    "fields": {
+      "rght": 201,
+      "code": "PAN",
+      "name": "Panama",
+      "parent": 3,
+      "level": 3,
+      "lft": 200,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 180,
+    "model": "base.region",
+    "fields": {
+      "rght": 498,
+      "code": "PNG",
+      "name": "Papua New Guinea",
+      "parent": 256,
+      "level": 2,
+      "lft": 497,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 181,
+    "model": "base.region",
+    "fields": {
+      "rght": 233,
+      "code": "PRY",
+      "name": "Paraguay",
+      "parent": 4,
+      "level": 3,
+      "lft": 232,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 182,
+    "model": "base.region",
+    "fields": {
+      "rght": 235,
+      "code": "PER",
+      "name": "Peru",
+      "parent": 4,
+      "level": 3,
+      "lft": 234,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 183,
+    "model": "base.region",
+    "fields": {
+      "rght": 307,
+      "code": "PHL",
+      "name": "Philippines",
+      "parent": 7,
+      "level": 3,
+      "lft": 306,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 184,
+    "model": "base.region",
+    "fields": {
+      "rght": 500,
+      "code": "PCN",
+      "name": "Pitcairn",
+      "parent": 256,
+      "level": 2,
+      "lft": 499,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 185,
+    "model": "base.region",
+    "fields": {
+      "rght": 402,
+      "code": "POL",
+      "name": "Poland",
+      "parent": 5,
+      "level": 2,
+      "lft": 401,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 186,
+    "model": "base.region",
+    "fields": {
+      "rght": 404,
+      "code": "PRT",
+      "name": "Portugal",
+      "parent": 5,
+      "level": 2,
+      "lft": 403,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 187,
+    "model": "base.region",
+    "fields": {
+      "rght": 167,
+      "code": "PRI",
+      "name": "Puerto Rico",
+      "parent": 255,
+      "level": 3,
+      "lft": 166,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 188,
+    "model": "base.region",
+    "fields": {
+      "rght": 454,
+      "code": "QAT",
+      "name": "Qatar",
+      "parent": 15,
+      "level": 2,
+      "lft": 453,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 189,
+    "model": "base.region",
+    "fields": {
+      "rght": 275,
+      "code": "KOR",
+      "name": "Republic of Korea",
+      "parent": 258,
+      "level": 3,
+      "lft": 274,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 190,
+    "model": "base.region",
+    "fields": {
+      "rght": 406,
+      "code": "MDA",
+      "name": "Republic of Moldova",
+      "parent": 5,
+      "level": 2,
+      "lft": 405,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 191,
+    "model": "base.region",
+    "fields": {
+      "rght": 37,
+      "code": "REU",
+      "name": "Reunion",
+      "parent": 12,
+      "level": 3,
+      "lft": 36,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 192,
+    "model": "base.region",
+    "fields": {
+      "rght": 408,
+      "code": "ROU",
+      "name": "Romania",
+      "parent": 5,
+      "level": 2,
+      "lft": 407,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 193,
+    "model": "base.region",
+    "fields": {
+      "rght": 410,
+      "code": "RUS",
+      "name": "Russian Federation",
+      "parent": 5,
+      "level": 2,
+      "lft": 409,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 194,
+    "model": "base.region",
+    "fields": {
+      "rght": 39,
+      "code": "RWA",
+      "name": "Rwanda",
+      "parent": 12,
+      "level": 3,
+      "lft": 38,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 195,
+    "model": "base.region",
+    "fields": {
+      "rght": 73,
+      "code": "SHN",
+      "name": "Saint Helena",
+      "parent": 14,
+      "level": 3,
+      "lft": 72,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 196,
+    "model": "base.region",
+    "fields": {
+      "rght": 169,
+      "code": "KNA",
+      "name": "Saint Kitts and Nevis",
+      "parent": 255,
+      "level": 3,
+      "lft": 168,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 197,
+    "model": "base.region",
+    "fields": {
+      "rght": 171,
+      "code": "LCA",
+      "name": "Saint Lucia",
+      "parent": 255,
+      "level": 3,
+      "lft": 170,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 198,
+    "model": "base.region",
+    "fields": {
+      "rght": 173,
+      "code": "SPM",
+      "name": "Saint Pierre and Miquelon",
+      "parent": 255,
+      "level": 3,
+      "lft": 172,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 199,
+    "model": "base.region",
+    "fields": {
+      "rght": 175,
+      "code": "VCT",
+      "name": "Saint Vincent and the Grenadines",
+      "parent": 255,
+      "level": 3,
+      "lft": 174,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 200,
+    "model": "base.region",
+    "fields": {
+      "rght": 177,
+      "code": "BLM",
+      "name": "Saint-Barthelemy",
+      "parent": 255,
+      "level": 3,
+      "lft": 176,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 201,
+    "model": "base.region",
+    "fields": {
+      "rght": 179,
+      "code": "MAF",
+      "name": "Saint-Martin (French part)",
+      "parent": 255,
+      "level": 3,
+      "lft": 178,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 202,
+    "model": "base.region",
+    "fields": {
+      "rght": 502,
+      "code": "WSM",
+      "name": "Samoa",
+      "parent": 256,
+      "level": 2,
+      "lft": 501,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 203,
+    "model": "base.region",
+    "fields": {
+      "rght": 412,
+      "code": "SMR",
+      "name": "San Marino",
+      "parent": 5,
+      "level": 2,
+      "lft": 411,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 204,
+    "model": "base.region",
+    "fields": {
+      "rght": 119,
+      "code": "STP",
+      "name": "Sao Tome and Principe",
+      "parent": 13,
+      "level": 3,
+      "lft": 118,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 205,
+    "model": "base.region",
+    "fields": {
+      "rght": 456,
+      "code": "SAU",
+      "name": "Saudi Arabia",
+      "parent": 15,
+      "level": 2,
+      "lft": 455,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 206,
+    "model": "base.region",
+    "fields": {
+      "rght": 121,
+      "code": "SEN",
+      "name": "Senegal",
+      "parent": 13,
+      "level": 3,
+      "lft": 120,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 207,
+    "model": "base.region",
+    "fields": {
+      "rght": 414,
+      "code": "SRB",
+      "name": "Serbia",
+      "parent": 5,
+      "level": 2,
+      "lft": 413,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 208,
+    "model": "base.region",
+    "fields": {
+      "rght": 41,
+      "code": "SYC",
+      "name": "Seychelles",
+      "parent": 12,
+      "level": 3,
+      "lft": 40,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 209,
+    "model": "base.region",
+    "fields": {
+      "rght": 123,
+      "code": "SLE",
+      "name": "Sierra Leone",
+      "parent": 13,
+      "level": 3,
+      "lft": 122,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 210,
+    "model": "base.region",
+    "fields": {
+      "rght": 309,
+      "code": "SGP",
+      "name": "Singapore",
+      "parent": 7,
+      "level": 3,
+      "lft": 308,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 211,
+    "model": "base.region",
+    "fields": {
+      "rght": 416,
+      "code": "SVK",
+      "name": "Slovakia",
+      "parent": 5,
+      "level": 2,
+      "lft": 415,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 212,
+    "model": "base.region",
+    "fields": {
+      "rght": 418,
+      "code": "SVN",
+      "name": "Slovenia",
+      "parent": 5,
+      "level": 2,
+      "lft": 417,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 213,
+    "model": "base.region",
+    "fields": {
+      "rght": 504,
+      "code": "SLB",
+      "name": "Solomon Islands",
+      "parent": 256,
+      "level": 2,
+      "lft": 503,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 214,
+    "model": "base.region",
+    "fields": {
+      "rght": 43,
+      "code": "SOM",
+      "name": "Somalia",
+      "parent": 12,
+      "level": 3,
+      "lft": 42,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 215,
+    "model": "base.region",
+    "fields": {
+      "rght": 75,
+      "code": "ZAF",
+      "name": "South Africa",
+      "parent": 14,
+      "level": 3,
+      "lft": 74,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 216,
+    "model": "base.region",
+    "fields": {
+      "rght": 420,
+      "code": "ESP",
+      "name": "Spain",
+      "parent": 5,
+      "level": 2,
+      "lft": 419,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 217,
+    "model": "base.region",
+    "fields": {
+      "rght": 291,
+      "code": "LKA",
+      "name": "Sri Lanka",
+      "parent": 9,
+      "level": 3,
+      "lft": 290,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 218,
+    "model": "base.region",
+    "fields": {
+      "rght": 59,
+      "code": "SDN",
+      "name": "Sudan",
+      "parent": 11,
+      "level": 3,
+      "lft": 58,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 219,
+    "model": "base.region",
+    "fields": {
+      "rght": 237,
+      "code": "SUR",
+      "name": "Suriname",
+      "parent": 4,
+      "level": 3,
+      "lft": 236,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 220,
+    "model": "base.region",
+    "fields": {
+      "rght": 422,
+      "code": "SJM",
+      "name": "Svalbard and Jan Mayen Islands",
+      "parent": 5,
+      "level": 2,
+      "lft": 421,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 221,
+    "model": "base.region",
+    "fields": {
+      "rght": 77,
+      "code": "SWZ",
+      "name": "Swaziland",
+      "parent": 14,
+      "level": 3,
+      "lft": 76,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 222,
+    "model": "base.region",
+    "fields": {
+      "rght": 424,
+      "code": "SWE",
+      "name": "Sweden",
+      "parent": 5,
+      "level": 2,
+      "lft": 423,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 223,
+    "model": "base.region",
+    "fields": {
+      "rght": 426,
+      "code": "CHE",
+      "name": "Switzerland",
+      "parent": 5,
+      "level": 2,
+      "lft": 425,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 224,
+    "model": "base.region",
+    "fields": {
+      "rght": 458,
+      "code": "SYR",
+      "name": "Syrian Arab Republic",
+      "parent": 15,
+      "level": 2,
+      "lft": 457,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 225,
+    "model": "base.region",
+    "fields": {
+      "rght": 255,
+      "code": "TJK",
+      "name": "Tajikistan",
+      "parent": 8,
+      "level": 3,
+      "lft": 254,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 226,
+    "model": "base.region",
+    "fields": {
+      "rght": 311,
+      "code": "THA",
+      "name": "Thailand",
+      "parent": 7,
+      "level": 3,
+      "lft": 310,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 227,
+    "model": "base.region",
+    "fields": {
+      "rght": 313,
+      "code": "TLS",
+      "name": "Timor-Leste",
+      "parent": 7,
+      "level": 3,
+      "lft": 312,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 228,
+    "model": "base.region",
+    "fields": {
+      "rght": 125,
+      "code": "TGO",
+      "name": "Togo",
+      "parent": 13,
+      "level": 3,
+      "lft": 124,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 229,
+    "model": "base.region",
+    "fields": {
+      "rght": 506,
+      "code": "TKL",
+      "name": "Tokelau",
+      "parent": 256,
+      "level": 2,
+      "lft": 505,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 230,
+    "model": "base.region",
+    "fields": {
+      "rght": 508,
+      "code": "TON",
+      "name": "Tonga",
+      "parent": 256,
+      "level": 2,
+      "lft": 507,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 231,
+    "model": "base.region",
+    "fields": {
+      "rght": 181,
+      "code": "TTO",
+      "name": "Trinidad and Tobago",
+      "parent": 255,
+      "level": 3,
+      "lft": 180,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 232,
+    "model": "base.region",
+    "fields": {
+      "rght": 61,
+      "code": "TUN",
+      "name": "Tunisia",
+      "parent": 11,
+      "level": 3,
+      "lft": 60,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 233,
+    "model": "base.region",
+    "fields": {
+      "rght": 428,
+      "code": "TUR",
+      "name": "Turkey",
+      "parent": 5,
+      "level": 2,
+      "lft": 427,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 234,
+    "model": "base.region",
+    "fields": {
+      "rght": 257,
+      "code": "TKM",
+      "name": "Turkmenistan",
+      "parent": 8,
+      "level": 3,
+      "lft": 256,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 235,
+    "model": "base.region",
+    "fields": {
+      "rght": 183,
+      "code": "TCA",
+      "name": "Turks and Caicos Islands",
+      "parent": 255,
+      "level": 3,
+      "lft": 182,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 236,
+    "model": "base.region",
+    "fields": {
+      "rght": 510,
+      "code": "TUV",
+      "name": "Tuvalu",
+      "parent": 256,
+      "level": 2,
+      "lft": 509,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 237,
+    "model": "base.region",
+    "fields": {
+      "rght": 45,
+      "code": "UGA",
+      "name": "Uganda",
+      "parent": 12,
+      "level": 3,
+      "lft": 44,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 238,
+    "model": "base.region",
+    "fields": {
+      "rght": 430,
+      "code": "UKR",
+      "name": "Ukraine",
+      "parent": 5,
+      "level": 2,
+      "lft": 429,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 239,
+    "model": "base.region",
+    "fields": {
+      "rght": 460,
+      "code": "ARE",
+      "name": "United Arab Emirates",
+      "parent": 15,
+      "level": 2,
+      "lft": 459,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 240,
+    "model": "base.region",
+    "fields": {
+      "rght": 432,
+      "code": "GBR",
+      "name": "United Kingdom",
+      "parent": 5,
+      "level": 2,
+      "lft": 431,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 241,
+    "model": "base.region",
+    "fields": {
+      "rght": 47,
+      "code": "TZA",
+      "name": "United Republic of Tanzania",
+      "parent": 12,
+      "level": 3,
+      "lft": 46,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 242,
+    "model": "base.region",
+    "fields": {
+      "rght": 185,
+      "code": "VIR",
+      "name": "United States Virgin Islands",
+      "parent": 255,
+      "level": 3,
+      "lft": 184,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 243,
+    "model": "base.region",
+    "fields": {
+      "rght": 211,
+      "code": "USA",
+      "name": "United States of America",
+      "parent": 2,
+      "level": 3,
+      "lft": 210,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 244,
+    "model": "base.region",
+    "fields": {
+      "rght": 239,
+      "code": "URY",
+      "name": "Uruguay",
+      "parent": 4,
+      "level": 3,
+      "lft": 238,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 245,
+    "model": "base.region",
+    "fields": {
+      "rght": 259,
+      "code": "UZB",
+      "name": "Uzbekistan",
+      "parent": 8,
+      "level": 3,
+      "lft": 258,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 246,
+    "model": "base.region",
+    "fields": {
+      "rght": 512,
+      "code": "VUT",
+      "name": "Vanuatu",
+      "parent": 256,
+      "level": 2,
+      "lft": 511,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 247,
+    "model": "base.region",
+    "fields": {
+      "rght": 241,
+      "code": "VEN",
+      "name": "Venezuela (Bolivarian Republic of)",
+      "parent": 4,
+      "level": 3,
+      "lft": 240,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 248,
+    "model": "base.region",
+    "fields": {
+      "rght": 315,
+      "code": "VNM",
+      "name": "Viet Nam",
+      "parent": 7,
+      "level": 3,
+      "lft": 314,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 249,
+    "model": "base.region",
+    "fields": {
+      "rght": 514,
+      "code": "WLF",
+      "name": "Wallis and Futuna Islands",
+      "parent": 256,
+      "level": 2,
+      "lft": 513,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 250,
+    "model": "base.region",
+    "fields": {
+      "rght": 63,
+      "code": "ESH",
+      "name": "Western Sahara",
+      "parent": 11,
+      "level": 3,
+      "lft": 62,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 251,
+    "model": "base.region",
+    "fields": {
+      "rght": 462,
+      "code": "YEM",
+      "name": "Yemen",
+      "parent": 15,
+      "level": 2,
+      "lft": 461,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 252,
+    "model": "base.region",
+    "fields": {
+      "rght": 79,
+      "code": "ZMB",
+      "name": "Zambia",
+      "parent": 14,
+      "level": 3,
+      "lft": 78,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 253,
+    "model": "base.region",
+    "fields": {
+      "rght": 81,
+      "code": "ZWE",
+      "name": "Zimbabwe",
+      "parent": 14,
+      "level": 3,
+      "lft": 80,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 254,
+    "model": "base.region",
+    "fields": {
+      "rght": 243,
+      "code": "AME",
+      "name": "Americas",
+      "parent": 1,
+      "level": 1,
+      "lft": 128,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 255,
+    "model": "base.region",
+    "fields": {
+      "rght": 186,
+      "code": "CRB",
+      "name": "Caribbean",
+      "parent": 254,
+      "level": 2,
+      "lft": 129,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 256,
+    "model": "base.region",
+    "fields": {
+      "rght": 515,
+      "code": "PAC",
+      "name": "Pacific",
+      "parent": 1,
+      "level": 1,
+      "lft": 464,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 257,
+    "model": "base.region",
+    "fields": {
+      "rght": 12,
+      "code": "CFR",
+      "name": "Central Africa",
+      "parent": 10,
+      "level": 2,
+      "lft": 3,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 258,
+    "model": "base.region",
+    "fields": {
+      "rght": 276,
+      "code": "EAS",
+      "name": "East Asia",
+      "parent": 6,
+      "level": 2,
+      "lft": 261,
+      "tree_id": 90
+    }
+  },
+  {
+    "pk": 259,
+    "model": "base.region",
+    "fields": {
+      "rght": 59,
+      "code": "SSD",
+      "name": "South Sudan",
+      "parent": 11,
+      "level": 3,
+      "lft": 58,
+      "tree_id": 90
+    }
+  }
 ]


### PR DESCRIPTION
Grabbed our previous list of regions from [here](https://github.com/MapStory/geonode/blob/master/geonode/base/fixtures/initial_data.json#L434) and added them to mapstory's initial_data.json.

From what I understand we use this in the Story Properties modal. the Explore page, and the Profile Edit form --- tho there is additional research that can be done on how the regionsAPI is used with the owners & resource API for mapstory and if it follows the practices geonode intended.

Of note: It was mentioned to me that django fixtures is deprecated so we may want a follow-up ticket on a long-term stable solution to having a list of regions available for users. 

Closes #698 and closes #685 for explore work.
Clears up a blocker for continuing on #653 