### PR TITLE
Addressing bugs with Uploads on profile page (716, 717, 718, 722)

### DIFF
--- a/mapstory/static/mapstory/js/src/profile.uploads.controller.js
+++ b/mapstory/static/mapstory/js/src/profile.uploads.controller.js
@@ -1,0 +1,52 @@
+(function() {
+  'use strict';
+
+  angular
+    .module('mapstory')
+    .controller('uploadsController', uploadsController);
+
+  function uploadsController($injector, $scope, UploadedData, $rootScope) { 
+    var vm = this;
+    var offset = 0;
+
+    vm.currentPage = 0;
+    vm.limit = 10;
+    vm.loading = true;
+    vm.uploads = [];
+    
+    var query = {
+      offset: offset, 
+      limit: vm.limit, 
+      user__username: USER
+    };
+
+    getUploads(query);
+
+    vm.pageChanged = function() {
+      query.offset = (vm.currentPage - 1) * vm.limit;
+      getUploads(query);
+    };
+
+    function getUploads(query) {
+      UploadedData.query(query).$promise.then(function(data) {
+        vm.loading = false;
+        vm.uploads = data.objects;
+        
+        //send counts to parent scope for tab display
+        $scope.counts.uploads = data.meta.total_count;
+
+        // showing x - y of z uploads
+        vm.startIndex = query.offset + 1;
+        vm.endIndex = query.offset + vm.uploads.length;
+      });
+    }
+
+    // if a user uploads a layer while on their profile page, 
+    // this will update the list without having to refresh the page
+    $rootScope.$on('upload:complete', function(event, args) {
+        if (args.hasOwnProperty('id')) {
+            getUploads(query);
+        }
+    });
+  };
+})();

--- a/mapstory/templates/people/_profile_tabs.html
+++ b/mapstory/templates/people/_profile_tabs.html
@@ -5,7 +5,7 @@
     <li class="active">
         <a href="#stories_list" data-toggle="tab">
             <div class="counter">
-            <span ng-bind="total_maps"></span>
+            <span ng-bind="counts.maps"></span>
             </div>
             {% trans "Stories" %} 
         </a>
@@ -13,7 +13,7 @@
     <li>
         <a href="#layers_list" data-toggle="tab">
             <div class="counter">
-            <span ng-bind="total_layers"></span>
+            <span ng-bind="counts.layers"></span>
             </div>
             {% trans "Layers" %} 
         </a>
@@ -22,7 +22,7 @@
         <li>
             <a href="#uploads_list" data-toggle="tab">
                 <div class="counter">
-                    <span ng-bind="totalItems"></span>
+                    <span ng-bind="counts.uploads"></span>
                 </div>
                 Uploads
             </a>

--- a/mapstory/templates/people/_uploads_tab.html
+++ b/mapstory/templates/people/_uploads_tab.html
@@ -1,0 +1,35 @@
+{% load i18n %}
+<div class="tab-pane" id="uploads_list" ng-controller="uploadsController as up">
+    <div class="no-content" ng-hide="up.uploads.length">
+        <h2>No Uploads.</h2>
+        <h4>
+            <a style="cursor: pointer" ng-controller="ImportController"
+               ng-click="open(null, '{{ STATIC_URL }}mapstory/partials/uploadWizard.html', '/uploaded/{{ site.assets.logo.name }}', '{{ STATIC_URL }}')">
+               Click here</a> to upload your data!.
+        </h4>
+    </div>
+    <div class="" ng-show="up.uploads.length">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8">
+                    <div ng-show="up.loading">
+                        <i class="fa fa-spinner fa-spin fa-3x"></i>
+                    </div>
+                    {% verbatim %}
+                        <div class="layer-upload-counts">Showing {{ up.startIndex }}-{{ up.endIndex }}
+                            of {{ counts.uploads }} uploads.
+                        </div>
+                    {% endverbatim %}
+                    <div ng-repeat="upload in up.uploads">
+                        <upload upload-object="upload" i="$index" static-url="{{ STATIC_URL }}"
+                            template-url="{{ STATIC_URL }}mapstory/partials/upload.html">
+                        </upload>
+                    </div>
+                    <uib-pagination total-items="counts.uploads" ng-change="up.pageChanged()" max-size="7" 
+                        class="pagination-sm" items-per-page="up.limit" ng-model="up.currentPage">
+                    </uib-pagination>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/mapstory/templates/people/profile_detail.html
+++ b/mapstory/templates/people/profile_detail.html
@@ -33,67 +33,42 @@
                         <div class="tabbable-line">
                             {% include 'people/_profile_tabs.html' %}
                             <div class="tab-content">
-                                <div class="tab-pane active" id="stories_list">
-                                    <div class="no-content" ng-if="results == null">
+                                <div class="tab-pane active" id="stories_list" ng-controller="storiesController as story">
+                                    <div class="no-content" ng-hide="story.cards.length > 0">
                                         <h2>No MapStories.</h2>
-                                        <h4>Create your first {% trans "Story" %} now.</h4>
                                     </div>
-                                    <div class="clearfix content-results">
-                                        <ul>
+                                    
+                                    <div ng-show="story.cards.length > 0">
+                                        <div class="clearfix content-results">  
+                                            <ul>
                                             {% verbatim %}
-                                                <li ng-repeat="item in stories" resource-id="{{ item.id }}"
-                                                    class="col-lg-4 col-sm-6 resource-{{ item.id }}">
+                                                <li ng-repeat="item in story.cards" resource-id="{{ item.id }}"
+                                                        class="col-lg-4 col-sm-6 resource-{{ item.id }}">
                                             {% endverbatim %}
                                             {% include 'search/_result_content.html' %}
-                                        </ul>
-                                    </div>
-                                </div>
-                                <div class="tab-pane" id="layers_list">
-                                    <div class="no-content" ng-if="results == null">
-                                        <h2>{% trans "No Layers" %}.</h2>
-                                        <h4>Import your first {% trans "Layer" %} now.</h4>
-                                    </div>
-                                    <div class="clearfix content-results">
-                                        <ul>
-                                            {% verbatim %}
-                                                <li ng-repeat="item in layers" resource-id="{{ item.id }}"
-                                                    class="col-lg-4 col-sm-6 resource-{{ item.id }}">
-                                            {% endverbatim %}
-                                            {% include 'search/_result_content.html' %}</ul>
-                                    </div>
-                                </div>
-                                <div class="tab-pane" id="uploads_list">
-                                    <div class="no-content" ng-hide="uploads.length">
-                                        <h2>No Uploads.</h2>
-                                        <h4><a style="cursor: pointer" ng-controller="ImportController"
-                                               ng-click="open(null, '{{ STATIC_URL }}mapstory/partials/uploadWizard.html', '/uploaded/{{ site.assets.logo.name }}', '{{ STATIC_URL }}')">Click
-                                            here</a> to upload your data!.</h4>
-                                    </div>
-                                    <div class="" ng-show="uploads.length">
-                                        <div class="container">
-                                            <div class="row">
-                                                <div class="col-md-8">
-                                                    <div ng-show="loading"
-                                                         style="margin-right: 50%; margin-left: 50%; margin-top: 30px; margin-bottom: 30px">
-                                                        <i class="fa fa-spinner fa-spin fa-3x"></i>
-                                                    </div>
-                                                    {% verbatim %}
-                                                        <div class="layer-upload-counts">Showing uploads {{ offset }}-{{ offset+uploads.length }}
-                                                            of {{ totalItems }}.
-                                                        </div>
-                                                    {% endverbatim %}
-                                                    <div ng-repeat="upload in uploads">
-                                                        <upload upload-object="upload" i="$index" static-url="{{ STATIC_URL }}"
-                                                                template-url="{{ STATIC_URL }}mapstory/partials/upload.html"></upload>
-                                                    </div>
-                                                    <uib-pagination total-items="totalItems" ng-init="init('{{ user.username }}')"
-                                                                    ng-change="pageChanged()" max-size="7" class="pagination-sm"
-                                                                    items-per-page="limit" ng-model="currentPage"></uib-pagination>
-                                                </div>
-                                            </div>
+                                            </ul>
                                         </div>
                                     </div>
                                 </div>
+                                <div class="tab-pane" id="layers_list" ng-controller="layersController as layer">
+                                    <div class="no-content" ng-hide="layer.cards.length > 0">
+                                        <h2>{% trans "No Layers" %}.</h2>
+                                    </div>
+                                    
+                                     <div ng-show="layer.cards.length > 0">
+                                        <div class="clearfix content-results">
+                                            <ul>
+                                            {% verbatim %}
+                                                <li ng-repeat="item in layer.cards" resource-id="{{ item.id }}"
+                                                        class="col-lg-4 col-sm-6 resource-{{ item.id }}">
+                                            {% endverbatim %}
+                                            {% include 'search/_result_content.html' %}</ul>
+                                        </div>
+                                    </div>
+                                </div>
+                                {% if user == profile %}
+                                    {% include 'people/_uploads_tab.html' %}
+                                {% endif %}
                                 <div class="tab-pane" id="messages_list">
                                     {% if not inbox_count %}
                                         <div class="no-content">
@@ -218,7 +193,6 @@
     <script type="text/javascript">
         PROFILE_USERNAME = "{{ profile.username }}";
         // Pass the keyword list from the django template into the javascript
-        keyword_list = "{{profile.keyword_list|escapejs}}";
     </script>
 
     {% if user == profile %}


### PR DESCRIPTION
closes #716 
closes #717 
closes #718 
closes #722 

on the profile page, showing x of y uploads isn't indexed in a human-friendly way
when a new upload is initialized while on your profile page, too many uploads show behind the modal
Interacting with uploads tab pagination introduces all user uploads to results
unauthorized user renders template & request for profile upload counts
profile uploads tab has separate html template and controller for organization
remove inline css styling, html formatting