### PR TITLE
Bump to current stable GeoNode release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 psycopg2==2.4.5
 numpy==1.8.2
 
-# -e ../geonode
--e git://github.com/GeoNode/geonode.git@2.6a1#egg=geonode
+geonode==2.6
 
 # Force Django 1.8.7: GeoNode's setup.py pulls in newer
 # despite GeoNode requirements.txt pinning 1.8.7


### PR DESCRIPTION
See also: geonode.org/blog/2017/05/17/geonode-2.6-released/