### PR TITLE
Update our GeoNode dependency: minor bugfix release for stable 2.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 psycopg2==2.4.5
 numpy==1.8.2
 
-geonode==2.6
+geonode==2.6.1
 
 # Force Django 1.8.7: GeoNode's setup.py pulls in newer
 # despite GeoNode requirements.txt pinning 1.8.7


### PR DESCRIPTION
This fixes the `django-oauth-toolkit`-related error we've been seeing in CI/new dev env setup/etc. See https://github.com/GeoNode/geonode/pull/3126 for more info.