### PR TITLE
Deployment fixes

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -90,6 +90,11 @@ services:
       - ./cover:/srv/mapstory/cover
       - site-packages:/usr/local/lib/python2.7/site-packages-copy
 
+  django_volumes:
+    entrypoint: /bin/sh -c "chown -R mapstory:mapstory /var/lib/mapstory && chown -R mapstory:mapstory /srv/mapstory/cover"
+    volumes:
+      - ./cover:/srv/mapstory/cover
+
   geoserver:
     links:
       - postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     build: .
     image: mapstory/django
     user: root
-    entrypoint: /bin/sh -c "chown -R mapstory:mapstory /var/lib/mapstory && chown -R mapstory:mapstory /srv/mapstory/cover"
+    entrypoint: /bin/sh -c "chown -R mapstory:mapstory /var/lib/mapstory"
     volumes:
       - mapstory_media:/var/lib/mapstory/media/
       - mapstory_static:/var/lib/mapstory/static/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,16 +25,16 @@ services:
       - "15671"
       - "15672"
 
-  python-gdal:
-    build: docker/python-gdal
-    image: mapstory/python-gdal
-    command: /bin/true
+#  python-gdal:
+#    build: docker/python-gdal
+#    image: mapstory/python-gdal
+#    command: /bin/true
 
   django:
     build: .
     image: mapstory/django
     depends_on:
-      - python-gdal
+#      - python-gdal
       - django_volumes
     links:
       - elasticsearch
@@ -51,7 +51,7 @@ services:
     build: .
     image: mapstory/django
     depends_on:
-      - python-gdal
+#      - python-gdal
       - django_volumes
     links:
       - elasticsearch


### PR DESCRIPTION
`python-gdal` now has its own auto build.
hopefully fixes the permissions for the `cover` directory