### PR TITLE
Address site-wide use of {{sitename}} variable as language for Stories.

### DIFF
--- a/mapstory/static/mapstory/js/src/search/explore.controller.js
+++ b/mapstory/static/mapstory/js/src/search/explore.controller.js
@@ -13,8 +13,6 @@
     var vm = this;
 
     $scope.query = $location.search();
-    $scope.sitename = SITE_NAME; //used in content_sidebar
-
     $scope.query.limit = $scope.query.limit || CLIENT_RESULTS_LIMIT;
     $scope.query.offset = $scope.query.offset || 0;
 

--- a/mapstory/templates/_site_scripts.html
+++ b/mapstory/templates/_site_scripts.html
@@ -14,7 +14,6 @@
     {% else %}
         SEARCH_URL = '{% url 'api_dispatch_list' api_name='api' resource_name='base' %}'
     {% endif %}
-    SITE_NAME = "{{SITE_NAME}}";
     USER = "{{ user }}";
 </script>
 

--- a/mapstory/templates/maps/_story_details.html
+++ b/mapstory/templates/maps/_story_details.html
@@ -25,14 +25,14 @@
                 <a href="/story/{{ resource.id }}/draft">
                     <button class="btn btn-danger resume-edit">
                         <i class="fa fa-pencil"></i>
-                        {% if resource.is_published %} Change Published {{SITE_NAME}} 
+                        {% if resource.is_published %} Change Published MapStory 
                         {% else %} Resume Draft 
                         {% endif %}
                     </button>
                 </a>
                 <a href="/story/{{ resource.id }}/embed">
                     <button class="btn btn-detail mobile-play">
-                        <i class="fa fa-play"></i> Play {{SITE_NAME}}  
+                        <i class="fa fa-play"></i> Play MapStory  
                     </button>
                 </a>
                 {% endif %}
@@ -95,7 +95,7 @@
                             {% if resource.abstract != '' %}
                                 {{ resource.abstract }}
                             {% else %}
-                                <div class="no-chapter-summary"> Unfortunately, no summary has been provided for this {{SITE_NAME}}.</div>
+                                <div class="no-chapter-summary"> Unfortunately, no summary has been provided for this MapStory.</div>
                             {% endif %}
                         </div>
                         {% if resource.chapters.count = 1 %}
@@ -245,7 +245,7 @@
                     {% if resource.owner == user %}
                     <div style= "padding-top: 40px">
                         <button class="btn btn-danger">
-                            <a href="{% url "map_remove" resource.id %}">{% trans "Delete this " %}{{SITE_NAME}}</a>
+                            <a href="{% url "map_remove" resource.id %}">{% trans "Delete this " %}MapStory</a>
                         </button>
                     </div>
                     {% endif %}

--- a/mapstory/templates/people/_activity_feed.html
+++ b/mapstory/templates/people/_activity_feed.html
@@ -3,7 +3,7 @@
 {% if action_list.count == 0 %}
     <div class="no-content">
         <h2>No activities.</h2>
-        <h4><a href="{% url "home" %}">Explore {{ SITE_NAME }} now.</a></h4>
+        <h4><a href="{% url "home" %}">Explore now.</a></h4>
     </div>
 {% endif %}
 <div class="row">

--- a/mapstory/templates/search/_content_sidebar.html
+++ b/mapstory/templates/search/_content_sidebar.html
@@ -60,7 +60,7 @@
                        data-filter="type__in"
                        ng-click="explore.checkboxQuery($event)"
                        ng-checked="isActivated('mapstory', query, 'type__in')">
-                    {{sitename}}
+                    MapStory
                 </input>
             </div>
         </div>

--- a/mapstory/templates/search/_result_content.html
+++ b/mapstory/templates/search/_result_content.html
@@ -6,7 +6,7 @@
             <div class="content-result-type">
                 <h4 class="tiny-caps">
                     <span ng-if="item.type === 'mapstory'"><i class="fa fa-map-o"></i>
-                        {% endverbatim %}{{SITE_NAME}}{% verbatim %}
+                        MapStory
                     </span>
                     <span ng-if="item.type === 'layer'"><i class="fa fa-clone"></i> StoryLayer</span>
                 </h4>

--- a/mapstory/templates/viewer/story_viewer.html
+++ b/mapstory/templates/viewer/story_viewer.html
@@ -32,7 +32,7 @@
         <div class="content">
             {% verbatim %}
             <a target="_blank" href="/story/{{ mapManager.storyMap.get('id') - 1 }}/view" class="viewer-story-title" ng-bind="mapManager.title"></a>
-            <a target="_blank" href="/storyteller/{{ mapManager.username }}" class="viewer-author">{% endverbatim %}{{ SITE_NAME }} {% verbatim %}by {{ mapManager.owner }}</a>
+            <a target="_blank" href="/storyteller/{{ mapManager.username }}" class="viewer-author">MapStory by {{ mapManager.owner }}</a>
             <div class="viewer-chapter-number">Chapter {{ mapManager.storyChapter}}</div>
             <div class="viewer-chapter-title" ng-bind="mapManager.storyMap.getStoryTitle()"></div>
             <p ng-bind="mapManager.storyMap.getStoryAbstract()"></p>


### PR DESCRIPTION
Addresses instances of {{site_name}} that were being used to populate text for content type (mapstory, storyscape, storylayer). I have the go-ahead to refer to all Story content as MapStory. 

Instances of Site Name used in the Journal, Header, Footer, etc as the name of the site are still being used.

Closes #837 