### PR TITLE
use https for avatar image

### DIFF
--- a/mapstory/templates/search/_result_users.html
+++ b/mapstory/templates/search/_result_users.html
@@ -5,7 +5,7 @@
             <div class="avatar-and-social-links">
                 <a href="/storyteller/{{ item.username }}">
                     <img class="thumb img-responsive img-circle"
-                         src="http://www.gravatar.com/avatar/b3770ff767657838215cefd0d00e7769/?s=100"
+                         src="https://www.gravatar.com/avatar/b3770ff767657838215cefd0d00e7769/?s=100"
                          ng-src="{{ item.avatar_100 }}"/>
                 </a>
                 <div class="social-icons">


### PR DESCRIPTION
When viewing search results on beta.mapstory.org mixed-content warnings are displayed by the browser.

I believe the ng-src value should over-ride this, so perhaps this isn't actually fixing the problem. But, it shouldn't hurt to at least change to https as the default.

Perhaps the existing src tag shouldn't exist? Or should be pointing to a MapStory specific asset as opposed to a generic gravatar image? Is `item.avatar_100` failing in some way?

