### PR TITLE
Change the story routes so that they contain a story title slug

### DIFF
--- a/mapstory/mapstories/migrations/0002_mapstory_slug.py
+++ b/mapstory/mapstories/migrations/0002_mapstory_slug.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import datetime
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mapstories', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='mapstory',
+            name='slug',
+            field=models.SlugField(default=datetime.datetime(2017, 7, 28, 14, 2, 48, 889460), max_length=160),
+            preserve_default=False,
+        ),
+    ]

--- a/mapstory/mapstories/models.py
+++ b/mapstory/mapstories/models.py
@@ -4,14 +4,12 @@ import uuid
 
 from django import core, db
 from django.db.models import signals
+from django.template.defaultfilters import slugify
 from django.utils.translation import ugettext_lazy as _
 # Redefining Map Model and adding additional fields
 
 
 class MapStory(geonode.base.models.ResourceBase):
-
-    def get_absolute_url(self):
-        return core.urlresolvers.reverse('mapstory.views.map_detail', None, [str(self.id)])
 
     @property
     def chapters(self):
@@ -25,6 +23,8 @@ class MapStory(geonode.base.models.ResourceBase):
         self.title = conf['title']
         self.abstract = conf['abstract']
         self.is_published = conf['is_published']
+        self.slug = slugify(conf['title'])
+
         if conf['category'] is not None:
             self.category = geonode.base.models.TopicCategory(conf['category'])
 
@@ -39,6 +39,10 @@ class MapStory(geonode.base.models.ResourceBase):
 
         #self.keywords.add(*conf['map'].get('keywords', []))
         self.save()
+
+    def get_absolute_url(self):
+        return '/story/' + str(self.id) + '/' + str(self.slug)
+
 
     def viewer_json(self, user):
 
@@ -87,6 +91,7 @@ class MapStory(geonode.base.models.ResourceBase):
         blank=True,
         null=True,
         help_text=distribution_description_help_text)
+    slug = db.models.SlugField(max_length=160)
 
 
     class Meta(geonode.base.models.ResourceBase.Meta):

--- a/mapstory/templates/maps/_story_details.html
+++ b/mapstory/templates/maps/_story_details.html
@@ -71,7 +71,7 @@
                         </div>
                         <h3>Map Services</h3>
                         <div class="embed">Share 
-                            <input id="shareStory" value ="https://{{ request.get_host }}{% url 'mapstory.views.map_detail' resource.id %}">
+                            <input id="shareStory" value ="https://{{ request.get_host }}{% url 'mapstory.views.map_detail' resource.id resource.slug %}">
                             <button class="copyclip btn" data-clipboard-target="#shareStory">
                                 <i class="fa fa-clipboard" aria-hidden="true"></i>
                             </button>  

--- a/mapstory/templates/maps/map_detail.html
+++ b/mapstory/templates/maps/map_detail.html
@@ -29,7 +29,7 @@
   {% autoescape off %}
       $('<iframe>', {
      {% if resource.chapters %}
-     src: '{%  url 'mapstory_view' resource.id %}',
+     src: '{%  url 'mapstory_view' resource.id resource.slug %}',
      {% else %}
      src: '{%  url 'map-viewer' resource.id %}',
      {% endif %}

--- a/mapstory/tests/utils.py
+++ b/mapstory/tests/utils.py
@@ -1,22 +1,19 @@
 """
 Test Utilities and helpers
 """
-import string
 import random
+import string
 from datetime import datetime
 from datetime import timedelta
-from itertools import cycle
 from uuid import uuid4
 
 from django.contrib.auth import get_user_model
 from django.db.models import signals
-
+from django.template.defaultfilters import slugify
 from geonode.base.models import TopicCategory
-from geonode.geoserver.signals import geoserver_pre_save_maplayer
 from geonode.geoserver.signals import geoserver_post_save_map, geoserver_pre_save, geoserver_post_save
+from geonode.geoserver.signals import geoserver_pre_save_maplayer
 from geonode.maps.models import MapLayer, Layer
-
-
 from mapstory.mapstories.models import Map
 from mapstory.mapstories.models import MapStory
 
@@ -92,7 +89,7 @@ def create_mapstory(owner, title):
     :param title: The story title
     :return: MapStory
     """
-    return MapStory.objects.create(owner=owner, title=title)
+    return MapStory.objects.create(owner=owner, title=title, slug=slugify(title))
 
 
 def id_generator(size=6, chars=string.ascii_uppercase + string.digits):
@@ -303,6 +300,6 @@ def create_layer(title, abstract, owner):
         date=start,
         storeType='dataStore',
         category=category,
-          )
+    )
     layer.save()
     return layer

--- a/mapstory/urls.py
+++ b/mapstory/urls.py
@@ -33,7 +33,7 @@ from mapstory.views import MapStorySignupView
 from mapstory.views import layer_detail, layer_detail_id, layer_create
 from mapstory.views import layer_acls_mapstory, resolve_user_mapstory
 from mapstory.views import layer_remove, map_remove
-from mapstory.views import map_detail
+from mapstory.views import map_detail, map_detail_redirect
 from mapstory.views import new_map
 from mapstory.views import ProfileDetail, profile_delete, profile_edit, proxy
 from mapstory.views import SearchView
@@ -90,9 +90,10 @@ urlpatterns = patterns('',
 
     # Story
     url(r'^story$', 'mapstory.views.new_story_json', name='new_story_json'),
-    url(r'^story/(?P<storyid>[^/]+)/save$', 'mapstory.views.save_story', name='save_story'),
-    url(r'^story/(?P<mapid>\d+)/?$', map_detail, name='mapstory_detail'),
-    url(r'^story/(?P<storyid>\d+)/view$', 'mapstory.views.mapstory_view', name='mapstory_view'),
+    url(r'^story/(?P<id>[^/]+)/save$', 'mapstory.views.save_story', name='save_story'),
+    url(r'^story/(?P<id>\d+)/(?P<slug>[-\w]+)/?$', map_detail, name='mapstory_detail'),
+    url(r'^story/(?P<id>\d+)/$', map_detail_redirect, name='mapstory_detail_redirect'),
+    url(r'^story/(?P<id>\d+)/(?P<slug>[-\w]+)/view$', 'mapstory.views.mapstory_view', name='mapstory_view'),
     url(r'^story/chapter/new$', 'mapstory.views.new_map_json', name='new_map_json'),
 
     # MapLoom


### PR DESCRIPTION
This PR contains several changes all relating to changing our story routes.  All stories will now have a slug that is a slugified version of the title.  This gets updated anytime a story is saved, so if the title is changed the slug will be as well.

The routes will now be /story/story-id-number/story-title-slugified.

If a user goes to just /story/story-id-number I've setup a function to ensure it redirects to the correct full path.  Part of the requirements given to me were to keep the ID number in the URL route.  I don't think this is necessary, and it clutters up the URL but it's there as per the requirements.  I'm open to changing how I've done the routes if anyone has any feedback.