### PR TITLE
Layer detail and remove views break if community editing turned off

### DIFF
--- a/mapstory/templates/layers/_details.html
+++ b/mapstory/templates/layers/_details.html
@@ -48,9 +48,15 @@
                     {% endif %}
                     <div  class="row">
                         <div class="col-sm-12">
-                            <ul class="nav nav-tabs details-tabs" ng-controller="geogigController">
+                            <ul class="nav nav-tabs details-tabs" 
+                                {% if GEOGIG_ENABLED and resource.link_set.geogig %} 
+                                    ng-controller="geogigController"
+                                 {% endif %}   
+                                >
                                 <li class="active"><a href="#Metadata" data-toggle="tab">About this StoryLayer</a></li>
+                                {% if GEOGIG_ENABLED and resource.link_set.geogig %} 
                                 <li><a href="#Edits" data-toggle="tab">Contributions ({% verbatim %}{{ stats.totalCommits| number}}{% endverbatim %})</a></li>
+                                {% endif %}  
                                 <li><a href="#Comments" data-toggle="tab">Comments ({{ num_comments }})</a></li>
                                 <li><a href="#ShareLayer" data-toggle="tab">Share</a></li>
                                 {% if resource.category %}

--- a/mapstory/templates/layers/layer_remove.html
+++ b/mapstory/templates/layers/layer_remove.html
@@ -10,11 +10,16 @@
 </div>
 <div class="row">
 {% get_comment_count for layer as num_comments %}
-  <div class="col-md-8" ng-controller="geogigController">
+
+  <div class="col-md-8">
     <p class="lead">
           Are you sure you want to delete this StoryLayer, <a href="{{ layer.get_absolute_url }}">{{ layer.title }}</a>?
     </p>
-    <p> This layer has {% verbatim %}{{ stats.totalCommits | number}}{% endverbatim %} community contributions and {{ num_comments }} comments that will also be removed. </p>
+    {% if GEOGIG_ENABLED and layer.link_set.geogig %}
+      <div ng-controller="geogigController">
+        <p> This layer has {% verbatim %}{{ stats.totalCommits | number}}{% endverbatim %} community contributions and {{ num_comments }} comments that will also be removed. </p>
+      </div>
+    {% endif %} 
   <div>
 </div>
     <form action="{% url 'layer_remove' layer.service_typename %}" method="POST">


### PR DESCRIPTION
Closes #897 by adding django rendering conditionals when the geogig controller is referenced.

This must've been broken since adding the contribution display count Oct 2016.

Now the contributions tab should be hidden completely on layers that don't have community editing. 

Also, please verify that upon layer deletion this second block of text only appears for layers that have been opened for community editing.  ((I think the actual removal is bonked right now tho))
![screen shot 2017-08-03 at 8 39 02 pm](https://user-images.githubusercontent.com/15912063/28953278-d26857c6-788b-11e7-928f-ccb8293c5ba5.png)
