### PR TITLE
Reinstating avatar functionality and elastic search indexing for the MapStoryProfile model avatar

### DIFF
--- a/mapstory/mapstory_profile/models.py
+++ b/mapstory/mapstory_profile/models.py
@@ -71,11 +71,11 @@ class MapstoryProfile(models.Model):
         return [kw.slug for kw in self.keywords.all()]
 
 def profile_post_save(instance, sender, **kwargs):
-    MapstoryProfile.objects.filter(id=instance.id).update(
+    MapstoryProfile.objects.filter(user_id=instance.id).update(
         avatar_100=avatar_url(instance, 100))
 
 def avatar_post_save(instance, sender, **kw):
-    MapstoryProfile.objects.filter(id=instance.user.id).update(
+    MapstoryProfile.objects.filter(user_id=instance.user.id).update(
         avatar_100=avatar_url(instance.user, 100))
 
 def create_mapstory_profile(sender, instance, created, **kwargs):

--- a/mapstory/templates/avatar/add.html
+++ b/mapstory/templates/avatar/add.html
@@ -1,0 +1,16 @@
+{% extends "site_base.html" %}
+{% load i18n avatar_tags %}
+{% load bootstrap_tags %}
+
+{% block body %}
+	<a href="{% url "profile_edit" user.username %}">{% trans "Back to edit your profile information" %}</a>
+	<p>{% trans "Your current avatar: " %}</p>
+    {% avatar user %}
+    {% if not avatars %}
+        <p>{% trans "You haven't uploaded an avatar yet. Please upload one now." %}</p>
+    {% endif %}
+    <form enctype="multipart/form-data" method="POST" action="{% url 'avatar_add' %}">
+        {{ upload_avatar_form.as_p }}
+        <p>{% csrf_token %}<input type="submit" value="{% trans "Upload New Image" %}" /></p>
+    </form>
+{% endblock %}

--- a/mapstory/templates/avatar/change.html
+++ b/mapstory/templates/avatar/change.html
@@ -20,7 +20,7 @@
         {{ upload_avatar_form.as_p }}
         <p>{% csrf_token %}<input id="avatar-file" type="submit" class="btn btn-primary" style="visibility: hidden" value="{% trans "Upload New Image" %}" /></p>
     </form>
-    <a class="btn btn-primary btn-danger" href="{% url 'avatar_delete' %}" id="delete_avatar" style="visibility: hidden">{% trans "Delete Your Avatar" %}</a>
+<!--     <a class="btn btn-primary btn-danger" href="{% url 'avatar_delete' %}" id="delete_avatar" style="visibility: hidden">{% trans "Delete Your Avatar" %}</a> -->
 {% endblock %}
 
 {% block extra_script %}

--- a/mapstory/templates/avatar/change.html
+++ b/mapstory/templates/avatar/change.html
@@ -1,0 +1,36 @@
+{% extends "site_base.html" %}
+{% load i18n avatar_tags %}
+{% load bootstrap_tags %}
+
+{% block body %}
+    <h4 class="page-header"><a href="{% url "edit_profile" user.username %}">{% trans "Back to edit your profile information" %}</a></h4>
+    <h5>{% trans "Your current avatar: " %}</h5>
+    {% avatar user %}
+    {% if not avatars %}
+        <p>{% trans "You haven't uploaded an avatar yet. Please upload one now." %}</p>
+    {% else %}
+        <form method="POST" action="{% url 'avatar_change' %}">
+            <ul>
+                {{ primary_avatar_form.as_ul }}
+            </ul>
+            <p>{% csrf_token %}<input type="submit" class="btn btn-primary" value="{% trans "Choose new Default" %}" /></p>
+        </form>
+    {% endif %}
+    <form enctype="multipart/form-data" method="POST" action="{% url 'avatar_add' %}">
+        {{ upload_avatar_form.as_p }}
+        <p>{% csrf_token %}<input id="avatar-file" type="submit" class="btn btn-primary" style="visibility: hidden" value="{% trans "Upload New Image" %}" /></p>
+    </form>
+    <a class="btn btn-primary btn-danger" href="{% url 'avatar_delete' %}" id="delete_avatar" style="visibility: hidden">{% trans "Delete Your Avatar" %}</a>
+{% endblock %}
+
+{% block extra_script %}
+{{ block.super }}
+<script type="text/javascript">
+    $('#id_avatar').change(function() {
+        $('#avatar-file').css('visibility', 'visible');
+    });
+    {% if avatars %}
+    $('#delete_avatar').css('visibility', 'visible');
+    {% endif %}
+</script>
+{% endblock %}

--- a/mapstory/templates/avatar/confirm_delete.html
+++ b/mapstory/templates/avatar/confirm_delete.html
@@ -1,0 +1,18 @@
+{% extends "site_base.html" %}
+{% load i18n avatar_tags %}
+
+{% block body %}
+    <a href="{% url "edit_profile" user.username %}">{% trans "Back to edit your profile information" %}</a>
+    <p>{% trans "Please select the avatars that you would like to delete." %}</p>
+    {% if not avatars %}
+        {% url 'avatar_change' as avatar_change_url %}
+        <p>{% blocktrans %}You have no avatars to delete. Please <a href="{{ avatar_change_url }}">upload one</a> now.{% endblocktrans %}</p>
+    {% else %}
+        <form method="POST" action="{% url 'avatar_delete' %}">
+            <ul>
+                {{ delete_avatar_form.as_ul }}
+            </ul>
+            <p>{% csrf_token %}<input type="submit" class="btn btn-primary" value="{% trans "Delete These" %}" /></p>
+        </form>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
Closes #684 
Closes #564 

Also addresses using `user_id` as primary key between Profile and MapStoryProfile tables for indexing post-save on avatar change or profile edit. (closes #905 )

To do: The 'delete avatar' wasn't staying in sync with elastic search the post save, so I've hidden that functionality temporarily. Need a follow up ticket for a post delete or whatnot.