### PR TITLE
Story Routes to Use Slugs

### DIFF
--- a/mapstory/mapstories/migrations/0002_mapstory_slug.py
+++ b/mapstory/mapstories/migrations/0002_mapstory_slug.py
@@ -14,7 +14,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='mapstory',
             name='slug',
-            field=models.SlugField(max_length=160, null=True),
-            preserve_default=False,
+            field=models.SlugField(max_length=160, unique=True, null=True),
         ),
     ]

--- a/mapstory/mapstories/migrations/0002_mapstory_slug.py
+++ b/mapstory/mapstories/migrations/0002_mapstory_slug.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mapstories', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='mapstory',
+            name='slug',
+            field=models.SlugField(max_length=160, null=True),
+            preserve_default=False,
+        ),
+    ]

--- a/mapstory/mapstories/models.py
+++ b/mapstory/mapstories/models.py
@@ -4,14 +4,12 @@ import uuid
 
 from django import core, db
 from django.db.models import signals
+from django.template.defaultfilters import slugify
 from django.utils.translation import ugettext_lazy as _
 # Redefining Map Model and adding additional fields
 
 
 class MapStory(geonode.base.models.ResourceBase):
-
-    def get_absolute_url(self):
-        return core.urlresolvers.reverse('mapstory.views.map_detail', None, [str(self.id)])
 
     @property
     def chapters(self):
@@ -25,6 +23,8 @@ class MapStory(geonode.base.models.ResourceBase):
         self.title = conf['title']
         self.abstract = conf['abstract']
         self.is_published = conf['is_published']
+        self.slug = slugify(conf['title'])
+
         if conf['category'] is not None:
             self.category = geonode.base.models.TopicCategory(conf['category'])
 
@@ -39,6 +39,9 @@ class MapStory(geonode.base.models.ResourceBase):
 
         #self.keywords.add(*conf['map'].get('keywords', []))
         self.save()
+
+    def get_absolute_url(self):
+        return '/story/' + str(self.slug)
 
     def viewer_json(self, user):
 
@@ -87,6 +90,7 @@ class MapStory(geonode.base.models.ResourceBase):
         blank=True,
         null=True,
         help_text=distribution_description_help_text)
+    slug = db.models.SlugField(max_length=160, null=True)
 
 
     class Meta(geonode.base.models.ResourceBase.Meta):

--- a/mapstory/mapstories/models.py
+++ b/mapstory/mapstories/models.py
@@ -23,7 +23,11 @@ class MapStory(geonode.base.models.ResourceBase):
         self.title = conf['title']
         self.abstract = conf['abstract']
         self.is_published = conf['is_published']
-        self.slug = slugify(conf['title'])
+        # Ensure that the slug is unique.
+        if not MapStory.objects.filter(slug=slugify(conf['title'])).exists():
+            self.slug = slugify(conf['title'])
+        else:
+            self.slug = slugify(conf['title']) + '-' + str(self.id)
 
         if conf['category'] is not None:
             self.category = geonode.base.models.TopicCategory(conf['category'])
@@ -90,7 +94,7 @@ class MapStory(geonode.base.models.ResourceBase):
         blank=True,
         null=True,
         help_text=distribution_description_help_text)
-    slug = db.models.SlugField(max_length=160, null=True)
+    slug = db.models.SlugField(max_length=160, null=True, unique=True)
 
 
     class Meta(geonode.base.models.ResourceBase.Meta):

--- a/mapstory/mapstories/models.py
+++ b/mapstory/mapstories/models.py
@@ -24,10 +24,14 @@ class MapStory(geonode.base.models.ResourceBase):
         self.abstract = conf['abstract']
         self.is_published = conf['is_published']
         # Ensure that the slug is unique.
-        if not MapStory.objects.filter(slug=slugify(conf['title'])).exists():
+        try:
+            instance = MapStory.objects.get(slug=slugify(conf['title']))
+            if instance.id == self.id:
+                self.slug = slugify(conf['title'])
+            else:
+                self.slug = slugify(conf['title']) + '-' + str(self.id)
+        except MapStory.DoesNotExist:
             self.slug = slugify(conf['title'])
-        else:
-            self.slug = slugify(conf['title']) + '-' + str(self.id)
 
         if conf['category'] is not None:
             self.category = geonode.base.models.TopicCategory(conf['category'])

--- a/mapstory/templates/maps/_story_details.html
+++ b/mapstory/templates/maps/_story_details.html
@@ -71,14 +71,14 @@
                         </div>
                         <h3>Map Services</h3>
                         <div class="embed">Share 
-                            <input id="shareStory" value ="https://{{ request.get_host }}{% url 'mapstory.views.map_detail' resource.id %}">
+                            <input id="shareStory" value ="https://{{ request.get_host }}{% url 'mapstory.views.map_detail' resource.slug %}">
                             <button class="copyclip btn" data-clipboard-target="#shareStory">
                                 <i class="fa fa-clipboard" aria-hidden="true"></i>
                             </button>  
                         </div>
                         {% if resource.chapters %}
                         <div class="embed"> Embed
-                            <input id="embedStory" value="<iframe style='border: none;' height='400' width='600' src='https://{{ request.get_host }}/story/{{ resource.id }}/embed'></iframe>">
+                            <input id="embedStory" value="<iframe style='border: none;' height='400' width='600' src='https://{{ request.get_host }}/story/{{ resource.slug }}/embed'></iframe>">
                             <button  class="copyclip btn" data-clipboard-target="#embedStory">
                                 <i class="fa fa-clipboard" aria-hidden="true"></i>
                             </button>

--- a/mapstory/templates/maps/map_detail.html
+++ b/mapstory/templates/maps/map_detail.html
@@ -29,7 +29,7 @@
   {% autoescape off %}
       $('<iframe>', {
      {% if resource.chapters %}
-     src: '{%  url 'mapstory_view' resource.id %}',
+     src: '{%  url 'mapstory_view' resource.slug %}',
      {% else %}
      src: '{%  url 'map-viewer' resource.id %}',
      {% endif %}

--- a/mapstory/tests/unit/test_mapstory.py
+++ b/mapstory/tests/unit/test_mapstory.py
@@ -84,7 +84,7 @@ class MapViewsTest(MapStoryTestMixin):
         found = MapStory.objects.get(id=test_mapstory.id)
         self.assertEquals(found.title, test_mapstory.title)
         # Should get a 200 response from the URL
-        response = self.client.get(reverse('mapstory_detail', kwargs={"mapid": test_mapstory.id}))
+        response = self.client.get(reverse('mapstory_detail', kwargs={"slug": test_mapstory.slug}))
         self.assertEquals(response.status_code, 200)
 
         # Should use the correct template
@@ -94,11 +94,11 @@ class MapViewsTest(MapStoryTestMixin):
     def test_post_mapstory_detail_keyword_post(self):
         # Should create add a keyword
         test_mapstory = create_mapstory(testUser, 'Testing Map 02')
-        response = self.client.post(reverse('mapstory_detail', kwargs={"mapid": test_mapstory.id}), {'add_keyword': 'test_keyword'})
+        response = self.client.post(reverse('mapstory_detail', kwargs={"slug": test_mapstory.slug}), {'add_keyword': 'test_keyword'})
         self.assertEquals(response.status_code, 200)
 
         # Should remove the keyword
-        response = self.client.post(reverse('mapstory_detail', kwargs={"mapid": test_mapstory.id}),
+        response = self.client.post(reverse('mapstory_detail', kwargs={"slug": test_mapstory.slug}),
                                     {'remove_keyword': 'test_keyword'})
 
         self.assertEquals(response.status_code, 200)
@@ -107,7 +107,7 @@ class MapViewsTest(MapStoryTestMixin):
         form_data = {'keywords': ['testKeyword01','testKeyword02','testKeyword03']}
         form = KeywordsForm(data=form_data)
         self.assertTrue(form.is_valid())
-        response = self.client.post(reverse('mapstory_detail', kwargs={"mapid": test_mapstory.id}), form_data)
+        response = self.client.post(reverse('mapstory_detail', kwargs={"slug": test_mapstory.slug}), form_data)
         self.assertEquals(response.status_code, 200)
 
     def test_mapstory_detail_publish_status_form(self):
@@ -120,7 +120,7 @@ class MapViewsTest(MapStoryTestMixin):
         form = PublishStatusForm(data=form_data)
         self.assertTrue(form.is_valid())
         response = self.client.post(reverse('mapstory_detail',
-                                            kwargs={"mapid": test_mapstory.id}), form_data)
+                                            kwargs={"slug": test_mapstory.slug}), form_data)
         self.assertEquals(response.status_code, 200)
 
         # Should be published
@@ -133,7 +133,7 @@ class MapViewsTest(MapStoryTestMixin):
         self.assertIsNotNone(test_mapstory.id)
 
         # Should get a 200 response from the URL
-        response = self.client.get(reverse('mapstory_detail', kwargs={"mapid": test_mapstory.id}))
+        response = self.client.get(reverse('mapstory_detail', kwargs={"slug": test_mapstory.slug}))
         self.assertEquals(response.status_code, 200)
 
         # Should use the correct template
@@ -161,7 +161,7 @@ class MapViewsTest(MapStoryTestMixin):
         self.assertIsNotNone(test_mapstory.id)
 
         # Should get a 200 response from the URL
-        response = self.client.get(reverse('mapstory_detail', kwargs={"mapid": test_mapstory.id}))
+        response = self.client.get(reverse('mapstory_detail', kwargs={"slug": test_mapstory.slug}))
         self.assertEquals(response.status_code, 200)
 
         # Should have the meta tags included

--- a/mapstory/tests/utils.py
+++ b/mapstory/tests/utils.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 
 from django.contrib.auth import get_user_model
 from django.db.models import signals
+from django.utils.text import slugify
 
 from geonode.base.models import TopicCategory
 from geonode.geoserver.signals import geoserver_pre_save_maplayer
@@ -92,7 +93,7 @@ def create_mapstory(owner, title):
     :param title: The story title
     :return: MapStory
     """
-    return MapStory.objects.create(owner=owner, title=title)
+    return MapStory.objects.create(owner=owner, title=title, slug=slugify(title))
 
 
 def id_generator(size=6, chars=string.ascii_uppercase + string.digits):

--- a/mapstory/urls.py
+++ b/mapstory/urls.py
@@ -100,7 +100,7 @@ urlpatterns = patterns('',
         name='new-story'),
     url(r'^maps/edit$', new_map, {'template': 'composer/maploom.html'}, name='map-edit'),
     url(r'^maps/(?P<mapid>\d+)/view$', 'mapstory.views.map_view', {'template': 'composer/maploom.html'}, name='map-view'),
-    url(r'^story/(?P<storyid>[^/]+)/draft$',
+    url(r'^story/(?P<slug>[-\w]+)/draft$',
     'mapstory.views.draft_view', {'template': 'composer/maploom.html'}, name='maploom-map-view'),
     url(r'^frame/(?P<storyid>[^/]+)/draft','mapstory.views.draft_view',name='draft_view'),
 

--- a/mapstory/urls.py
+++ b/mapstory/urls.py
@@ -107,7 +107,7 @@ urlpatterns = patterns('',
     # StoryTools
     url(r'^maps/(?P<mapid>\d+)/viewer$', 'mapstory.views.map_view', {'template': 'viewer/story_viewer.html'}, name='map-viewer'),
     url(r'^maps/(?P<mapid>\d+)/embed$', 'mapstory.views.map_view', {'template': 'viewer/story_viewer.html'}, name='map-viewer'),
-    url(r'^story/(?P<storyid>\d+)/embed$', 'mapstory.views.mapstory_view', {'template': 'viewer/story_viewer.html'}, name='mapstory-viewer'),
+    url(r'^story/(?P<slug>[-\w]+)/embed$', 'mapstory.views.mapstory_view', {'template': 'viewer/story_viewer.html'}, name='mapstory-viewer'),
 
     url(r"^storyteller/delete/(?P<username>[^/]*)/$", profile_delete, name="profile_delete"),
     url(r"^storyteller/edit/(?P<username>[^/]*)/$", profile_edit, name="edit_profile"),

--- a/mapstory/urls.py
+++ b/mapstory/urls.py
@@ -91,8 +91,8 @@ urlpatterns = patterns('',
     # Story
     url(r'^story$', 'mapstory.views.new_story_json', name='new_story_json'),
     url(r'^story/(?P<storyid>[^/]+)/save$', 'mapstory.views.save_story', name='save_story'),
-    url(r'^story/(?P<mapid>\d+)/?$', map_detail, name='mapstory_detail'),
-    url(r'^story/(?P<storyid>\d+)/view$', 'mapstory.views.mapstory_view', name='mapstory_view'),
+    url(r'^story/(?P<slug>[-\w]+)/?$', map_detail, name='mapstory_detail'),
+    url(r'^story/(?P<slug>[-\w]+)/view$', 'mapstory.views.mapstory_view', name='mapstory_view'),
     url(r'^story/chapter/new$', 'mapstory.views.new_map_json', name='new_map_json'),
 
     # MapLoom

--- a/mapstory/urls.py
+++ b/mapstory/urls.py
@@ -91,7 +91,7 @@ urlpatterns = patterns('',
     # Story
     url(r'^story$', 'mapstory.views.new_story_json', name='new_story_json'),
     url(r'^story/(?P<storyid>[^/]+)/save$', 'mapstory.views.save_story', name='save_story'),
-    url(r'^story/(?P<slug>[-\w]+)/?$', map_detail, name='mapstory_detail'),
+    url(r'^story/(?P<slug>[-\w]+)/$', map_detail, name='mapstory_detail'),
     url(r'^story/(?P<slug>[-\w]+)/view$', 'mapstory.views.mapstory_view', name='mapstory_view'),
     url(r'^story/chapter/new$', 'mapstory.views.new_map_json', name='new_map_json'),
 

--- a/mapstory/views.py
+++ b/mapstory/views.py
@@ -406,13 +406,13 @@ def map_view(request, mapid, snapshot=None, template='maps/map_view.html'):
     }))
 
 
-def mapstory_view(request, storyid, snapshot=None, template='viewer/story_viewer.html'):
+def mapstory_view(request, slug, snapshot=None, template='viewer/story_viewer.html'):
     """
     The view that returns the map viewer opened to
     the mapstory with the given ID.
     """
 
-    story_obj = _resolve_map(request, storyid, 'base.view_resourcebase', _PERMISSION_MSG_VIEW)
+    story_obj = _resolve_map(request, slug, 'base.view_resourcebase', _PERMISSION_MSG_VIEW)
 
     if snapshot is None:
         config = story_obj.viewer_json(request.user)
@@ -979,18 +979,18 @@ def _resolve_map(request, id, permission='base.change_resourcebase',
     if id.isdigit():
         key = 'pk'
     else:
-        key = 'urlsuffix'
+        key = 'slug'
     map_obj = resolve_object(request, MapStory, {key: id}, permission=permission,
                           permission_msg=msg, **kwargs)
     return map_obj
 
 
-def map_detail(request, mapid, snapshot=None, template='maps/map_detail.html'):
+def map_detail(request, slug, snapshot=None, template='maps/map_detail.html'):
     '''
     The view that show details of each map
     '''
 
-    map_obj = _resolve_map(request, mapid, 'base.view_resourcebase', _PERMISSION_MSG_VIEW)
+    map_obj = _resolve_map(request, slug, 'base.view_resourcebase', _PERMISSION_MSG_VIEW)
 
     # Update count for popularity ranking,
     # but do not includes admins or resource owners
@@ -1038,7 +1038,7 @@ def map_detail(request, mapid, snapshot=None, template='maps/map_detail.html'):
 
     map_thumbnail_dir = os.path.join(settings.MEDIA_ROOT, 'thumbs')
     map_default_thumbnail_array = map_obj.get_thumbnail_url().split('/')
-    map_default_thumbnail_name = 'map' + str(mapid) + '.jpg'
+    map_default_thumbnail_name = 'map' + str(slug) + '.jpg'
     map_default_thumbnail = os.path.join(map_thumbnail_dir,
                                          map_default_thumbnail_name)
 

--- a/mapstory/views.py
+++ b/mapstory/views.py
@@ -496,9 +496,9 @@ def new_story_json(request):
         )
 
 
-def draft_view(request, storyid, template='composer/maploom.html'):
+def draft_view(request, slug, template='composer/maploom.html'):
 
-    story_obj = _resolve_story(request, storyid, 'base.change_resourcebase', _PERMISSION_MSG_SAVE)
+    story_obj = _resolve_story(request, slug, 'base.change_resourcebase', _PERMISSION_MSG_SAVE)
 
     config = story_obj.viewer_json(request.user)
 

--- a/mapstory/views.py
+++ b/mapstory/views.py
@@ -1072,7 +1072,7 @@ def map_detail(request, slug, snapshot=None, template='maps/map_detail.html'):
     update_es_index(MapStory, MapStory.objects.get(id=map_obj.id))
 
     # This will get URL encoded later and is used for the social media share URL
-    share_url = "https://%s/story/%s" % (request.get_host(), map_obj.id)
+    share_url = "https://%s/story/%s" % (request.get_host(), map_obj.slug)
     share_title = "%s by %s." % (map_obj.title, map_obj.owner)
     share_description = map_obj.abstract
 

--- a/mapstory/views.py
+++ b/mapstory/views.py
@@ -433,7 +433,7 @@ def _resolve_story(request, id, permission='base.change_resourcebase',
     if id.isdigit():
         key = 'pk'
     else:
-        key = 'urlsuffix'
+        key = 'slug'
     return resolve_object(request, MapStory, {key: id}, permission=permission,
                           permission_msg=msg, **kwargs)
 


### PR DESCRIPTION
This PR changes the routes where stories are involved, they now use proper slugs instead of ID numbers.  I also changed the draft view to use slugs as well.  I have a case that checks for slugs being unique, and if they aren't, the PK ID of the story is tacked onto the end of the slug itself to make it unique.