### PR TITLE
Removes the delay from the deletion tasks allowing them to work

### DIFF
--- a/mapstory/views.py
+++ b/mapstory/views.py
@@ -1105,7 +1105,7 @@ def layer_remove(request, layername, template='layers/layer_remove.html'):
         }))
     if (request.method == 'POST'):
         try:
-            delete_layer.delay(object_id=layer.id)
+            delete_layer(object_id=layer.id)
         except Exception as e:
             message = '{0}: {1}.'.format(_('Unable to delete layer'), layer.typename)
 
@@ -1115,7 +1115,7 @@ def layer_remove(request, layername, template='layers/layer_remove.html'):
 
             messages.error(request, message)
             return render_to_response(template, RequestContext(request, {"layer": layer}))
-        return HttpResponseRedirect(reverse("index_view"))
+        return HttpResponseRedirect(reverse("profile_detail", kwargs={'slug': layer.owner}))
     else:
         return HttpResponse("Not allowed", status=403)
 
@@ -1131,7 +1131,7 @@ def map_remove(request, mapid, template='maps/map_remove.html'):
         }))
 
     elif request.method == 'POST':
-        delete_mapstory.delay(object_id=map_obj.id)
+        delete_mapstory(object_id=map_obj.id)
         return HttpResponseRedirect(reverse("profile_detail", kwargs={'slug': map_obj.owner}))
 
 


### PR DESCRIPTION
This removes a delay that was previously on the tasks for deleting layers and stories.  I've tested this and it fixes the issue of the layers and stories not actually being deleted.  I'm not 100% sure why the delay was there in the first place, but I have not seen any adverse effects from removing it.