### PR TITLE
Fixes Create with Spaces in Name

### DIFF
--- a/mapstory/importers.py
+++ b/mapstory/importers.py
@@ -83,7 +83,7 @@ class GeoServerLayerCreator(Import):
             layer['geoserver_store'] = {'type': 'geogig'}
             store = layer.get('geoserver_store')
             if store.get('type', str).lower() == 'geogig':
-                name = feature_type['name'].lower()
+                name = slugify(feature_type['name'])
                 store.setdefault('branch', 'master')
                 store.setdefault('create', 'true')
                 store.setdefault('name', name)


### PR DESCRIPTION
Slugifies the name that the user passes during the create process so that the store can be created.  This closes https://github.com/MapStory/mapstory/issues/925