### PR TITLE
942 and 926 homepage fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ ghostdriver.log
 mapstory/tests/errors/err*
 mapstory/tests/errors/known/err*
 mapstory/tests/e2e/images/diff/
+ll_scripts/

--- a/mapstory/templates/_footer.html
+++ b/mapstory/templates/_footer.html
@@ -21,7 +21,7 @@
         </section>
         <section layout="column" flex-gt-sm="33">
             <h3 class="bold-caps">Ways to Connect</h3>
-            <p>We want to hear from you! Visit <a href="https://github.com/MapStory/mapstory/wiki">the Wiki</a> to find and share more
+            <p>We want to hear from you! Visit <a href="https://wiki.mapstory.org">the Wiki</a> to find and share more
                 resources with the community</p>
             <p>Find us on Github or Twitter. Use the feedback tool below to report any issues
                 you encounter</p>

--- a/mapstory/templates/index.html
+++ b/mapstory/templates/index.html
@@ -34,14 +34,14 @@
     <section class="featured-cards" ng-controller="featuredController as featured">
         <div layout="column" layout-align="start center">
             <h2 class="homepage">Featured MapStories from Across the Community</h2>
-            <div layout="row" layout-sm="column" layout-xs="column" style="max-width: 1750px;"">
+            <div layout="row" layout-sm="column" layout-xs="column" style="max-width: 1750px;">
                 <ul layout="row" class="no-style-list" layout-wrap layout-align="center center">
                     <li ng-repeat="item in featured.cards">
                         {% include 'cards/_featured.html' %}
                     </li>
                 </ul>
             </div>
-            <a href="/getstarted">
+            <a href="{% url 'search' %}">
                 <button class="button button-inverse">
                     <span>See More</span>
                 </button>


### PR DESCRIPTION
Changes:
- Changed 'See More' link navigation to `Explore page`
- Changed wiki link navigation to `wiki.mapstory.org`
- Deleted a rogue `"` character inside homepage.

Issues:
- Closes #942
- Closes #926