### PR TITLE
Update to Geonode 2.6.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -68,6 +68,3 @@ selenium
 
 # Activity Streams
 django-activity-stream==0.6.1
-
-# Pin to a specific version of Shapely as future versions break the build.
-shapely==1.5.17


### PR DESCRIPTION
The latest version of Geonode has a fix that we need for Shapely, it pins Shapely to a specific version as future versions break our builds.  Closes https://github.com/MapStory/mapstory/issues/992