### PR TITLE
665 Volunteer Technical Community filter for Mapstory Profiles

### DIFF
--- a/mapstory/api/api.py
+++ b/mapstory/api/api.py
@@ -5,7 +5,7 @@ from django.db.models import Q
 
 from geonode.api.api import TypeFilteredResource, CountJSONSerializer
 from tastypie import http, fields
-from tastypie.constants import ALL
+from tastypie.constants import ALL, ALL_WITH_RELATIONS
 
 from mapstory.mapstory_profile.models import MapstoryProfile
 
@@ -33,6 +33,9 @@ class MapstoryProfileResource(TypeFilteredResource):
     class Meta:
         queryset = MapstoryProfile.objects.all()
 
+        filtering = {
+            'Volunteer_Technical_Community': ALL
+        }
 
 class MapstoryOwnersResource(TypeFilteredResource):
     """Mapstory's version of GeoNode's /api/owners Resource """
@@ -108,5 +111,6 @@ class MapstoryOwnersResource(TypeFilteredResource):
             'username': ALL,
             'city': ALL,
             'country': ALL,
+            'mapstoryprofile': ALL_WITH_RELATIONS
         }
         serializer = OwnerProfileSerializer()

--- a/mapstory/static/mapstory/js/src/search/explore.controller.js
+++ b/mapstory/static/mapstory/js/src/search/explore.controller.js
@@ -86,24 +86,6 @@
       $scope.search();
     };
 
-    // Volunteer Technical Community checkbox is a front-end show/hide filter
-    // The following functions toggle the visibility of the _result_users card
-
-    vm.clearVTC = function(){
-      vm.VTCisChecked = false;
-      $scope.itemFilter = { is_active: true };
-      $scope.search();
-    };
-
-    vm.filterVTC = function() {
-      // When VTC check box is clicked, also filter by VTC; when unchecked, reset it
-      if (vm.VTCisChecked) {
-        $scope.itemFilter = {Volunteer_Technical_Community: true}; 
-      } else {
-        $scope.itemFilter = { is_active: true };  
-      }
-    };
-
     //////////////
     /* ORDERING */
     //set default order methods for content and storyteller

--- a/mapstory/templates/search/_result_users.html
+++ b/mapstory/templates/search/_result_users.html
@@ -1,6 +1,6 @@
 {% verbatim %}
 <div>
-    <li ng-repeat="item in cards | orderBy: orderMethodStoryteller | filter:itemFilter" resource-id="{{ item.id }}" class="col-lg-6">
+    <li ng-repeat="item in cards | orderBy: orderMethodStoryteller" resource-id="{{ item.id }}" class="col-lg-6">
         <div class="storyteller-card">
             <div class="avatar-and-social-links">
                 <a href="/storyteller/{{ item.username }}">

--- a/mapstory/templates/search/_users_sidebar.html
+++ b/mapstory/templates/search/_users_sidebar.html
@@ -150,11 +150,16 @@
                             </a>
                             can answer questions and help if you send them a message.
                         </p>
-                        <label>
-                          <input type="checkbox" ng-model="explore.VTCisChecked" ng-click="explore.filterVTC()"> 
-                          VTC Members only
-                        </label>
-                    <!--     <input type="checkbox" ng-model="query.Volunteer_Technical_Community" ng-click="VTC()"> VTC Members only -->
+                  
+                      <label>
+                        <input type="checkbox"
+                          data-value="true"
+                          data-filter="mapstoryprofile__Volunteer_Technical_Community"
+                          ng-click="explore.checkboxQuery($event)"
+                          ng-checked="isActivated('true', query, 'mapstoryprofile__Volunteer_Technical_Community')">
+                        </input>
+                        VTC Members only
+                      </label>
                     </div>
                 </section>
             </aside>

--- a/mapstory/templates/search/_users_sidebar.html
+++ b/mapstory/templates/search/_users_sidebar.html
@@ -145,7 +145,7 @@
                     <h3 class="bold-caps">VTC Members</h3>
                     <div class="filter-content">
                         <p>
-                            <a href="{% url 'getpage' 'started' %}#Join%20the%20Volunteer%20Technical%20Community">
+                            <a href="http://wiki.mapstory.org/Volunteer_Technical_Community">
                                 Volunteer Technical Community (VTC) members
                             </a>
                             can answer questions and help if you send them a message.


### PR DESCRIPTION
This should be the last of the "front end filtering" issues that we'd accumulated on the search page (along with the sorting #981 / #939 ) 

Now, no matter the query, it should persist on a page refresh and carry the sorting and filtering across multiple pages of API results. 

Overview of API solution: Since we have 2 profile tables (geonode's profile, and mapstoryprofile that are serialized together in our ownersAPI) in MapstoryOwnersResource I added `'mapstoryprofile': ALL_WITH_RELATIONS` to allow filtering by our custom table, and then in MapstoryProfileResource I added `'Volunteer_Technical_Community': ALL` to do the filtering. 

If there are other Mapstory profile fields we want to filter by in the future (i.e. Education, Expertise) this is where we would also do that. 

Closes #665 