### PR TITLE
939 sort again

### DIFF
--- a/mapstory/static/mapstory/js/src/search/explore.controller.js
+++ b/mapstory/static/mapstory/js/src/search/explore.controller.js
@@ -88,10 +88,6 @@
 
     //////////////
     /* ORDERING */
-    //set default order methods for content and storyteller
-    $scope.orderMethodContent = '-popular_count';
-    $scope.orderMethodStoryteller = 'username';
-
     //expose additional sorting to the dropdown "sort by"
     $scope.orderMethods = {
       //for general content results
@@ -107,6 +103,12 @@
           {name: 'Username A-Z', filter: 'username'}
         ]
     };
+
+    //set up a watch to re-pull results from API when ordering is changed
+    $scope.$watch('query["order_by"]', function (newValue, oldValue, scope) {
+      $scope.search();
+    });
+
     /////////////////////
     /* USER VS CONTENT */
     // Persisting content and storyteller view & queries through page refresh 

--- a/mapstory/static/mapstory/js/src/search/explore.controller.js
+++ b/mapstory/static/mapstory/js/src/search/explore.controller.js
@@ -129,11 +129,13 @@
         content: true, 
         is_published: true, 
         limit: CLIENT_RESULTS_LIMIT, 
-        offset: 0 
+        offset: 0,
+        order_by: '-popular_count'
       };
       $scope.search();
     };
     
+    //// Default settings upon landing (without clicking topbar/switch) ///
     if ($scope.query.storyteller){
       //storyteller explore
       $scope.apiEndpoint = '/api/owners/';
@@ -147,6 +149,8 @@
       //add is_published even if they've removed it,
       //but persist all other filters
       $scope.query.is_published = true;
+      // default order method for content
+      $scope.query.order_by='-popular_count';
     }
 
     $scope.search();

--- a/mapstory/static/mapstory/js/src/search/explore.controller.js
+++ b/mapstory/static/mapstory/js/src/search/explore.controller.js
@@ -53,9 +53,7 @@
           }
         )
     };
-
-
-
+    
     ////////////////////////////
     /*  Query Methods */
     // add, remove, checkbox( aka, toggle), and clear
@@ -89,22 +87,31 @@
     //////////////
     /* ORDERING */
     //expose additional sorting to the dropdown "sort by"
-    $scope.orderMethods = {
-      //for general content results
-      content:
+    $scope.orderingOptions = {
+      //select order_by options from the Resource API
+      resource:
         [
-          {name:'Popular', filter:'-popular_count'},
-          {name:'Newest', filter:'-date'}
+          { name:'Popular', 
+            sort:'-popular_count'
+          },
+          { name:'Newest',
+            sort:'-date'
+          }
         ], 
-        //for the storyteller results
-      storyteller:
+      //seclect order_by options from the Owners API
+      owner:
         [
-          {name: 'Username Z-A', filter: '-username'},
-          {name: 'Username A-Z', filter: 'username'}
+          { name: 'Username Z-A',
+            sort: '-username'
+          },
+          { name: 'Username A-Z',
+            sort: 'username'
+          }
         ]
     };
 
-    //set up a watch to re-pull results from API when ordering is changed
+    //set up a quick watch to re-pull results from API when ordering is changed
+    // todo: sync this up in other watches if we can for performance 
     $scope.$watch('query["order_by"]', function (newValue, oldValue, scope) {
       $scope.search();
     });

--- a/mapstory/static/mapstory/js/src/search/explore.controller.js
+++ b/mapstory/static/mapstory/js/src/search/explore.controller.js
@@ -117,7 +117,8 @@
       $scope.query = { 
         storyteller: true, 
         limit: CLIENT_RESULTS_LIMIT, 
-        offset: 0 
+        offset: 0,
+        order_by: 'username'
       };
      $scope.search();
     };

--- a/mapstory/templates/search/_result_users.html
+++ b/mapstory/templates/search/_result_users.html
@@ -1,6 +1,6 @@
 {% verbatim %}
 <div>
-    <li ng-repeat="item in cards | orderBy: orderMethodStoryteller" resource-id="{{ item.id }}" class="col-lg-6">
+    <li ng-repeat="item in cards" resource-id="{{ item.id }}" class="col-lg-6">
         <div class="storyteller-card">
             <div class="avatar-and-social-links">
                 <a href="/storyteller/{{ item.username }}">

--- a/mapstory/templates/search/explore.html
+++ b/mapstory/templates/search/explore.html
@@ -39,7 +39,7 @@
                 <div class="content-results">
                     <ul>
                         {% verbatim %}
-                        <li ng-repeat="item in cards | orderBy: orderMethodContent"
+                        <li ng-repeat="item in cards"
                             resource-id="{{ item.id }}"
                             class="col-lg-4 col-sm-6 resource-{{ item.id }}">
                         {% endverbatim %}

--- a/mapstory/templates/search/explore.html
+++ b/mapstory/templates/search/explore.html
@@ -29,7 +29,7 @@
                     <md-input-container class="md-block" flex-gt-md>
                         <label>Sort by</label>
                         <md-select ng-model="query.order_by">
-                          <md-option ng-repeat="state in orderMethods.content" value="{{state.filter}}">
+                          <md-option ng-repeat="state in orderingOptions.resource" value="{{state.sort}}">
                             {{state.name}}
                           </md-option>
                         </md-select>
@@ -67,7 +67,7 @@
                     <md-input-container class="md-block" flex-gt-md>
                         <label>Sort by</label>
                         <md-select ng-model="query.order_by">
-                          <md-option ng-repeat="state in orderMethods.storyteller" value="{{state.filter}}">
+                          <md-option ng-repeat="state in orderingOptions.owner" value="{{state.sort}}">
                             {{state.name}}
                           </md-option>
                         </md-select>

--- a/mapstory/templates/search/explore.html
+++ b/mapstory/templates/search/explore.html
@@ -28,7 +28,7 @@
                 
                     <md-input-container class="md-block" flex-gt-md>
                         <label>Sort by</label>
-                        <md-select ng-model="orderMethodContent">
+                        <md-select ng-model="query.order_by">
                           <md-option ng-repeat="state in orderMethods.content" value="{{state.filter}}">
                             {{state.name}}
                           </md-option>
@@ -66,7 +66,7 @@
                 <div class="sort-by">
                     <md-input-container class="md-block" flex-gt-md>
                         <label>Sort by</label>
-                        <md-select ng-model="orderMethodStoryteller">
+                        <md-select ng-model="query.order_by">
                           <md-option ng-repeat="state in orderMethods.storyteller" value="{{state.filter}}">
                             {{state.name}}
                           </md-option>


### PR DESCRIPTION
Issue description: The ordering / sorting methods on the explore page were front-end based and didn't affect what content was being pulled from the API. In local and test environs, since there weren't more than 1 page of results, these methods appeared to work, as they sorted a single page worth of results into the anticipated order. It came to my attention during the "featured cards" work that these methods were doing nothing to sort results _before_ they reach the browser and therefore were ineffective to sort content across multiple pages of results. Closes #939 

TLDR: we are now sorting results server side rather than client side :)

## To test:

- Change your results-per-page limit [here](https://github.com/MapStory/mapstory/blob/master/mapstory/static/mapstory/js/src/search/explore.controller.js#L16) to `2` or `3` 
    - make sure you run `grunt concat` from `mapstory/static` anytime you change js (or `grunt watch`)
    - alternatively you can do this [here](https://github.com/MapStory/mapstory/blob/53efb615668b9cccfdf403c6ea995543a1490b63/mapstory/settings/base.py#L546) in the base settings, then do whatever to have an instance running with that updated setting

##### Content Sorting: 

- Have some content (layers and/or stories) with view counts 
    - either modified via the admin panel [layers](https://docker/admin/layers/layer/) `Popular count:` field.
    - or racked up via viewing a detail page from a non-admin, non-resource owner account  

- Verify that your results are sorted (across pages) in highest to lowest view count upon landing on the page, AND upon selecting 'Popular' from the dropdown menu on the right, 
- Verify that your results update and are sorted from Newest to Oldest upon selecting 'Newest' from the dropdown menu on the right


##### StoryTeller Sorting:
- You should still have 2 or 3 results per-page from the step above
- Have or create multiple user accounts
- Select the "StoryTellers" Tab at the top of the explore page
- Verify that your results are sorted A-Z by Username upon landing on the page AND upon selecting 'Username A-Z' from the dropdown on the right
- Verify that your results are updated and sorted Z-A by username upon selecting 'Username Z-A' from the dropdown on the right. 


Go ahead and change your search limit back, or just checkout the file. 
Thanks!