### PR TITLE
Removing UI for autocomplete until Interests are set up to be queryable 

### DIFF
--- a/mapstory/static/mapstory/js/src/search/autocomplete.controllers.js
+++ b/mapstory/static/mapstory/js/src/search/autocomplete.controllers.js
@@ -14,9 +14,16 @@
   function interestsController ($injector, $scope, chipFieldFactory, dataService){
     var vm = this;
     vm.interests = new chipFieldFactory('interest_list', 'slug');
-    vm.async = function(searchText) {
-      return dataService.getKeywords({slug__icontains: searchText})
-    }; 
+    /*  since geonode 2.6. the KEYWORDS_ENDPOINT returns results from the h_keyword list,
+        but not non-hierarchical keywords. 
+        Currently our profiles save keywords as "tags", not h_keywords
+
+        a way to query all profile keywords to return slugs needs to be built
+        commenting out this functionality until then
+    */
+    // vm.async = function(searchText) {
+    //   return dataService.getKeywords({slug__icontains: searchText})
+    // }; 
 
     function interestChipSync(){
       var currentQuery = vm.interests.tidy($scope.query);

--- a/mapstory/templates/search/_users_sidebar.html
+++ b/mapstory/templates/search/_users_sidebar.html
@@ -117,11 +117,11 @@
                         {% verbatim %}
                         <md-content class="md-padding" layout="column">
                             <md-chips ng-model="int.chips" 
-                                md-autocomplete-snap 
                                 md-on-add="explore.addQuery('interest_list', $chip.slug)"
                                 md-on-remove="explore.removeQuery('interest_list', $chip.slug)"
-                                md-transform-chip="int.interests.newChip($chip)">
-                              <md-autocomplete
+                                md-transform-chip="int.interests.newChip($chip)"
+                                placeholder="Filter by an interest...">
+<!-- /* SEE: interestController.async() notes */ <md-autocomplete
                                   ng-hide="int.disabled"
                                   md-selected-item="selectedItem"
                                   md-search-text="searchText"
@@ -129,7 +129,7 @@
                                   md-item-text="item.code"
                                   placeholder="Filter by an interest...">
                                 <span md-highlight-text="searchText">{{item.slug}}</span>
-                              </md-autocomplete>
+                              </md-autocomplete> -->
                               <md-chip-template>
                                 {{$chip.slug}}
                               </md-chip-template>


### PR DESCRIPTION
See: #701 

Updating the issue to "**An API query is needed to return or query a list of all "Interests" from the owners/profiles tables**" to reflect the current state of the issue. 

As per Sara:

> So the problem here is centered around GeoNode 2.6's major change to using "h_keywords" (hierarchical keywords); the KEYWORDS_ENDPOINT in the example above returns results from the h_keyword list, but not non-hierarchical keywords. Currently our profiles save keywords as "tags", not h_keywords (forgive the jargon: TL;DR, two different types of searchable keywords fields)

With this PR, UI for storytellers interest won't act like an autocomplete anymore to set expected behavior, but unfortunately it is the only field that won't be autocompleting. 