### PR TITLE
Pin geonode-user-messages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 # Temporary. 1.0.8 has breaking changes.
 gsconfig==1.0.6
 
+# New version breaks the unit tests
+geonode-user-messages==0.1.6
+
 psycopg2==2.4.5
 numpy==1.8.2
 


### PR DESCRIPTION
because the new version breaks the unit tests