### PR TITLE
add docker troubleshooting info to main github page

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,15 @@ docker-compose pull
 docker-compose up -d
 ```
 
-Your local site should now be available at `http://docker/`.
+After a few minutes, your local site should be available at `http://docker/`.
+
+If you get a "502 Bad Gateway" error;
+
+```
+docker-compose up django_volume
+docker-compose restart django
+```
+
 
 Additional information about using the docker build is available at our [Docker README](https://github.com/MapStory/mapstory/blob/master/docker/README.md).
 


### PR DESCRIPTION
I had two issues while trying to get the containers up;
a) going to "http://docker" too early gives an error -- added doc to say it takes a while
b) I think the filesystem container came up too late relative to the django container  -- added doc for making sure that its up and restarting django  (thanks to @cuttlefish )