### PR TITLE
Allowing posting of keywords from /story/title/ urls

### DIFF
--- a/mapstory/mapstories/models.py
+++ b/mapstory/mapstories/models.py
@@ -104,7 +104,7 @@ class MapStory(geonode.base.models.ResourceBase):
         self.save()
 
     def get_absolute_url(self):
-        return '/story/' + str(self.slug)
+        return '/story/' + str(self.slug) + '/'
 
     def viewer_json(self, user):
 


### PR DESCRIPTION
Since switching to the story/title slug routing for mapstories, users have been unable to POST keywords from these endpoints. The story/id routing was still working tho.

Upon inspection I got `RuntimeError: You called this URL via POST, but the URL doesn't end in a slash and you have APPEND_SLASH set. Django can't redirect to the slash URL while maintaining POST data. Change your form to point to docker/story/im-a-single-chapter-story/ (note the trailing slash), or set APPEND_SLASH=False in your Django settings` so I added a trailing slash. Coop recommended this method rather than changing the django settings.

This should allow keyword postings from any new story via the /story/title/ routes, but **we may need to update existing resources in the elastic search json** from the API for this to take affect and allow tags on existing production data. 

Closes #1129 