### PR TITLE
Respect user-chosen case for text; do not truncate it

### DIFF
--- a/mapstory/static/style/site/cards.less
+++ b/mapstory/static/style/site/cards.less
@@ -70,7 +70,6 @@
     }
     .content-title {
         overflow-wrap: break-word;
-        text-transform: capitalize;
         font-weight: 500;
         font-size: 1.1em;
         color: @gray-900;

--- a/mapstory/templates/search/_result_content.html
+++ b/mapstory/templates/search/_result_content.html
@@ -30,7 +30,7 @@
         </div>
 
         <a href="{{ item.detail_url }}">
-            <h3 class="content-title">{{ item.title.toLowerCase() | limitTo:19 }}</h3>
+            <h3 class="content-title">{{ item.title }}</h3>
         </a>
 
         <h4 class="tiny-caps">


### PR DESCRIPTION
via @lhcramer: "On the content cards, The titles don't respect the user's capitalization and they cut off long titles instead of adding ellipses or word-wrap." 

This PR relies on word-wrap and respects the case given by the user.
When given longer titles, the card will allow a short scrollbar to view remaining content. 

Story titles won't be more than 160 characters, (added #1130 to address form validation in storyproperties modal) but for follow up we still need to check on what is allowed and/or validated for layer title lengths.

closes #1105 

