### PR TITLE
Make mobile-only thumbnail display of story clickable to the fullscre…

### DIFF
--- a/mapstory/templates/maps/_story_details.html
+++ b/mapstory/templates/maps/_story_details.html
@@ -19,7 +19,9 @@
                     </div>
                 </div>
                 <div class="mobile-thumb">
-                    <img ng-src="{{ thumbnail }}" src="{{ thumbnail }}">
+                    <a href="/story/{{ resource.id }}/embed">
+                        <img ng-src="{{ thumbnail }}" src="{{ thumbnail }}">
+                    </a>
                 </div>
                 {% if user == resource.owner %}
                 <a href="/story/{{ resource.id }}/draft">


### PR DESCRIPTION
…en story view.

Closes #1103 
> when you pull up a story on a mobile phone (like i-Phone) the mobile-friendly 'play button' doesn't show. It works when scaling down the page in the browser, but not on specific devices (similar to recent modification to homepage header). Test this out w/ dev tools and make sure there's a way to play a story via accessing the storyview on the specific mobile device settings. -- reported by: @jonpmarino


My chrome devtools show the "play story" buttons as exposed on the iphone5 and iphone6 displays. They _should_ display on anything smaller than 768px. Unfortunately, without more info I'm unsure what's happening here that doesn't display it on actual i-phones.

In the meantime I'm making the mobile-only thumbnail display **directly clickable** to the full-screen story viewer. Though @lhcramer suggested that in future designs we may want to transition to a play icon super imposed on top of the thumbnail for these mobile views.

## To test: 
open a story detail page using your chrome dev tools as any phone-sized mobile device. The thumbnail that display in lieu of the map should link to full screen view of that same story (note: I'm kinda expecting users to rotate their phones here to see it better)
