### PR TITLE
New default avatar sizing fallbacks (closes #1057)

### DIFF
--- a/mapstory/static/style/site/base.less
+++ b/mapstory/static/style/site/base.less
@@ -356,3 +356,8 @@ form {
   width: auto !important;
   padding: 0.4em;
 }
+
+// manipulates size of the default avatar returned from geonode/avatar template tags used in geonode/user_messages thread_detail.html 
+.message-avatar img {
+  max-height: 50px;
+}

--- a/mapstory/static/style/site/base.less
+++ b/mapstory/static/style/site/base.less
@@ -361,3 +361,7 @@ form {
 .message-avatar img {
   max-height: 50px;
 }
+// same, for {% avatar user 30 %} used in _message_snippet.html
+.inbox-avatar img {
+  max-height: 30px;
+}

--- a/mapstory/static/style/site/detailpages.less
+++ b/mapstory/static/style/site/detailpages.less
@@ -325,6 +325,12 @@ input[name=post] {
   padding: 3px;
   img {
     border-radius: 3px;
+    // size catch for default avatar. 
+    // warning: this will get out of sync with the template tags 
+    // & requests used to generate avatars if we don't keep an eye on it
+    // if we change any {% avatar user _size_%} template tags we should check
+    // this here too for the default grey avatar to match
+    max-height: 50px;
   }
 }
 

--- a/mapstory/static/style/site/profile.less
+++ b/mapstory/static/style/site/profile.less
@@ -154,13 +154,6 @@
   }
 }
 
-
-.avatar {
-  padding: 3px;
-  img {
-   border-radius: 3px;
-  }
-}
 #paralaxSlice1 {
   width:100%;
   background-repeat: repeat;

--- a/mapstory/templates/user_messages/_message_snippet.html
+++ b/mapstory/templates/user_messages/_message_snippet.html
@@ -1,0 +1,46 @@
+{% load i18n %}
+
+{% load avatar_tags %}
+
+<table class="table table-striped table-bordered table-condensed">
+    <thead>
+        <tr>
+            <td><strong>{% trans "With" %}</strong></td>
+            <td><strong>{% trans "Subject" %}</strong></td>
+            <td><strong>{% trans "Last Sender" %}</strong></td>
+            <td><strong>{% trans "Preview" %}</strong></td>
+            <td><strong>{% trans "Delete?" %}</strong></td>
+        </tr>
+        </thead>
+        <tbody>
+        {% for thread in threads %}
+        <tr>
+            <td>
+                {% for user in thread.users.all %}
+                    {% ifnotequal request.user user %}
+                        <p class="inbox-avatar">{% avatar user 30 %}</p>
+                        <a href="{{ user.get_absolute_url }}">{{ user }}</a>
+                    {% endifnotequal %}
+                {% endfor %}
+            </td>
+            <td><a href="{{ thread.get_absolute_url }}">{{ thread.subject }}</a></td>
+            <td>
+                {% ifequal request.user thread.latest_message.sender %}
+                  {% trans "me" %}
+                {% else %}
+                  <a href="{{ thread.latest_message.sender.get_absolute_url }}">{{ thread.latest_message.sender }}</a>
+                {% endifequal %}
+            </td>
+            <td>
+                {{ thread.latest_message.content|slice:"50" }}<a href="{{ thread.get_absolute_url }}">...</a>
+            </td>
+            <td>
+                <form id="thread_delete_{{ thread.pk }}" method="post" action="{% url "messages_thread_delete" thread.pk %}">
+                    {% csrf_token %}
+                    <button class="btn btn-danger message_delete_btn">{% trans "Delete" %}</button>
+                </form>
+            </td>
+        </tr>
+        {% endfor %}
+        </tbody>
+</table>

--- a/mapstory/templates/user_messages/thread_detail.html
+++ b/mapstory/templates/user_messages/thread_detail.html
@@ -1,0 +1,35 @@
+{% extends "site_base.html" %}
+
+{% load i18n %}
+{% load avatar_tags %}
+
+{% block title %}{{ thread.subject }} — {{ block.super }}{% endblock %}
+
+{% block body %}
+<h3>{{ thread.subject }}</h3>
+<hr />
+{% for message in thread.messages.all %}
+  <div class="well">
+    <span class="message-avatar">
+      {% avatar message.sender 50 %}
+    </span>
+    {{ message.sent_at }} by {% ifequal request.user message.sender %}{% trans "me" %}{% else %}<a href="{{ message.sender.get_absolute_url }}">{{ message.sender }}</a>{% endifequal %}
+    <p>{{ message.content }}</p>
+  </div>
+  {% empty %}
+  You have no messages.
+{% endfor %}
+<div>
+  <form action="{{ thread.get_absolute_url }}" method="post">
+    {% csrf_token %}
+    <fieldset>
+      <textarea name="content"></textarea>
+    </fieldset>
+    <input type="submit" value="{% trans "Send Reply" %}" class="btn btn-primary" type="button"/>
+  </form>
+</div>
+{% endblock %}
+
+{% block sidebar %}
+<a href="{% url "messages_inbox" %}" class="btn btn-primary" type="button">{% trans "Back to Inbox" %}</a>
+{% endblock %}


### PR DESCRIPTION
Here lies a front-end solution to close #1057 

## Proposed short term solution:
I've pulled in the templates `_message_snippet.html` and `_thread_detail.html` from `geonode/templates/user_messages` to add the following classes for selection 

-  `inbox-avatar` 
- `message-avatar`

I also added a height fallback in css for our comment avatars visible on Journal and Layer Detail pages under the `.avatar img` selectors. 

## Immediate follow up:
Following this PR I will try and get these html classes into the message templates on core geonode so others may select the avatars for styling as well, if and when those changes are merged in, we can remove these duplicate files in `mapstory/templates/user_messages` unless further deviation from core geonode is desired.

## Recommendation for future work:
An alternative to these front-end solutions would be setting up the[ get_default_avatar](https://github.com/GeoNode/geonode-avatar/blob/1c043e5d6e7abd66100ddd7e6084b160fff55496/avatar/util.py#L46) utility function (either inside of or outside of core geonode) to also handle the syntax used in the avatar template tags to request a size i.e. `{% avatar message.sender 50 %}`.  As of now, as written in PR #902 [(see code here)](https://github.com/MapStory/mapstory/pull/902/commits/7fcfa2dc9ddee9373ee953f7428b0554ec666204) it will return the large size we have as the site setting of `AVATAR_DEFAULT_URL`

Extending the `get_default_avatar` function (or learning to properly utilize it) would be beneficial as each of these front end solutions become tech debt / maintainability issues and are likely to fall out of sync with changes to the template tags used to call appropriate avatar sizes. I.e. if we change any of the django template tags in order to request a different size avatar for the profile page redesign or something, we will also have to change this fallback css for the default avatar to be the new size. (hence the extra comments in the .less files)

I'm also recommending that it is ok for _this review_ that the mapstory default avatar appears smaller (as a circle) than the geonode-driven user avatars that render as a square in messages and comments. If we are choosing to address this I recommend a site-wide style choice be implemented **thoroughly** on avatars everywhere for users and groups with the aid of a UI Designer and style guidelines.

## To test:
Have a user with a custom avatar and a user without one (defaulting to the grey silhouette) 
Comment with each on a layer.
Comment with each on a journal entry.
Send messages from each one to the other (two separate threads)
Respond to messages from each other.

Avatars in the inbox are expected be 30px tall/wide
Avatars in the message threads are expected be 50px tall/wide.
Avatars in comments are expected to be 50px tall/wide.

