### PR TITLE
Adjusting table view styling in maploom for visibility #1152 & #1140

### DIFF
--- a/mapstory/static/style/maps/maploom.less
+++ b/mapstory/static/style/maps/maploom.less
@@ -26,3 +26,11 @@ a#start-tour:hover, a#start-composing:hover{
 .loom-dialog.dialog-warning .modal-footer{
 	border-top: none;
 }
+
+#table-view i{
+	color: black;
+}
+
+#table-view-window .modal-body{
+	overflow: unset;
+}

--- a/mapstory/templates/maps/_story_details.html
+++ b/mapstory/templates/maps/_story_details.html
@@ -168,7 +168,7 @@
                                 md-on-remove="removeTag($chip)"
                                 md-transform-chip="newChip($chip)"
                                 md-separator-keys="separateOn"
-                                placeholder="Add tags for this StoryLayer...">
+                                placeholder="Add tags for this MapStory...">
                                 </md-chips>
                             </md-content>
                         </div>


### PR DESCRIPTION
Closes #1152 and #1140 

![screen shot 2017-12-30 at 1 06 20 am](https://user-images.githubusercontent.com/15912063/34452196-a644ba16-ecff-11e7-9b86-21fb7e6697e1.png)

![screen shot 2017-12-30 at 1 06 35 am](https://user-images.githubusercontent.com/15912063/34452194-a379e25c-ecff-11e7-90b1-cca28e39f2c4.png)

also, the placeholder on MapStory detail page tags had same text from StoryLayer tags sorry!