### PR TITLE
Fix tests for PRs generated from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,10 @@ addons:
     tunnel_domains: docker
 
 before_install:
-  - echo "Travis repo $TRAVIS_REPO_SLUG";
-    echo "Travis branch $TRAVIS_BRANCH";
+  - echo "Travis PR repo $TRAVIS_PULL_REQUEST_SLUG";
+    echo "Travis PR branch $TRAVIS_PULL_REQUEST_BRANCH";
+    echo "Travis target repo $TRAVIS_REPO_SLUG";
+    echo "Travis target branch $TRAVIS_BRANCH";
     echo "Travis build number $TRAVIS_BUILD_NUMBER";
     echo "Travis commit $TRAVIS_COMMIT";
   - if [ -z "$SAUCE_ACCESS_KEY" ]; then echo "Sauce is not available"; else echo "Sauce is available."; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ addons:
     tunnel_domains: docker
 
 before_install:
+  - set
   # Temporary fix for the Basho repo being down
   - sudo rm -vf /etc/apt/sources.list.d/*riak*
   # Install Docker Engine

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ addons:
     tunnel_domains: docker
 
 before_install:
+  - echo "Travis repo: TRAVIS_REPO_SLUG";
+    echo "Travis branch: $TRAVIS_BRANCH";
+    echo "Travis build number: $TRAVIS_BUILD_NUMBER";
+    echo "Travis commit: $TRAVIS_COMMIT";
   - if [ -z "$SAUCE_ACCESS_KEY" ]; then echo "Sauce is not available"; else echo "Sauce is available."; fi
   # Install Docker Engine
   - sudo apt-get update
@@ -75,8 +79,10 @@ script:
   # Wait for django container to come up
   - while [[ "$(curl -skL -o /dev/null -w ''%{http_code}'' docker)" != "200" ]]; do (echo "Waiting for webserver ($(curl -skL -o /dev/null -w ''%{http_code}'' docker))"; sleep 5); done
   - if [ -z "$SAUCE_ACCESS_KEY" ]; then
+      echo "Sauce is not available";
       $DCO up protractor;
     else
+      echo "Sauce is available";
       pushd mapstory/tests;
       SOURCE_HOME=/home/travis/build/MapStory/mapstory ./runAllTests.sh;
       popd;

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ addons:
 
 before_install:
   - set
-  # Temporary fix for the Basho repo being down
-  - sudo rm -vf /etc/apt/sources.list.d/*riak*
   # Install Docker Engine
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,10 @@ addons:
     tunnel_domains: docker
 
 before_install:
-  - echo "Travis repo: TRAVIS_REPO_SLUG";
-    echo "Travis branch: $TRAVIS_BRANCH";
-    echo "Travis build number: $TRAVIS_BUILD_NUMBER";
-    echo "Travis commit: $TRAVIS_COMMIT";
+  - echo "Travis repo $TRAVIS_REPO_SLUG";
+    echo "Travis branch $TRAVIS_BRANCH";
+    echo "Travis build number $TRAVIS_BUILD_NUMBER";
+    echo "Travis commit $TRAVIS_COMMIT";
   - if [ -z "$SAUCE_ACCESS_KEY" ]; then echo "Sauce is not available"; else echo "Sauce is available."; fi
   # Install Docker Engine
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
     tunnel_domains: docker
 
 before_install:
-  - set
+  - if [ -z "$SAUCE_ACCESS_KEY" ]; then echo "Sauce is not available"; else echo "Sauce is available."; fi
   # Install Docker Engine
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
   hostname: docker
   hosts:
     - docker
-  # For sauceLabs (DO NOT REMOVE)
+  # For SauceLabs (DO NOT REMOVE)
   sauce_connect:
     tunnel_domains: docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
   - $DCO up -d postgres elasticsearch rabbitmq
   - $DCO up pgadmin
   - $DCO run django "--init-db --collect-static --reindex"
-  - npm install -g protractor pix-diff
+  - if [ ! -z "$SAUCE_ACCESS_KEY" ]; then npm install -g protractor pix-diff; fi
   - sudo cp scripts/accept.sh /usr/local/bin/accept
 
 script:
@@ -71,11 +71,18 @@ script:
   - $DCO kill django
   - $DCO run -e TRAVIS=$TRAVIS -e TRAVIS_BRANCH=$TRAVIS_BRANCH -e TRAVIS_JOB_ID=$TRAVIS_JOB_ID django --init-db --test
   - $DCO up -d django
+  # Use the docker selenium setup if running on a fork's PR because Sauce credentials aren't available
+  - if [ -z "$SAUCE_ACCESS_KEY" ]; then $DCO up -d selenium; fi
   # Wait for django container to come up
   - while [[ "$(curl -skL -o /dev/null -w ''%{http_code}'' docker)" != "200" ]]; do (echo "Waiting for webserver ($(curl -skL -o /dev/null -w ''%{http_code}'' docker))"; sleep 5); done
-  - pushd mapstory/tests
-  - SOURCE_HOME=/home/travis/build/MapStory/mapstory ./runAllTests.sh
-  - popd
+  - if [ -z "$SAUCE_ACCESS_KEY" ]; then
+      $DCO up protractor;
+    else
+      pushd mapstory/tests;
+      SOURCE_HOME=/home/travis/build/MapStory/mapstory ./runAllTests.sh;
+      popd;
+    fi
+  - echo "tests are done"
 
 ### Currently quay.io is pulling the repos automatically
 # after_success:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -10,17 +10,6 @@ services:
     expose:
       - "4444"
 
-  # sauce-connect:
-  #   build: docker/sauce-connect
-  #   image: quay.io/mapstory/sauce-connect:master
-  #   env_file:
-  #     - .sauce
-  #   command: --tunnel-domains=docker
-  #   networks:
-  #     internal:
-  #   expose:
-  #     - "4445"
-
   protractor:
     build:
       context: .
@@ -28,7 +17,6 @@ services:
     image: quay.io/mapstory/protractor:master
     links:
       - selenium
-#      - sauce-connect
       - nginx
     volumes:
       - ./mapstory/tests:/opt/mapstory/tests

--- a/docker/docker-compose.travis.yml
+++ b/docker/docker-compose.travis.yml
@@ -2,6 +2,29 @@
 version: '3.1'
 services:
 
+  # This is used when building on forks because auth tokens for Sauce are unavailable
+  selenium:
+    image: selenium/standalone-chrome
+    links:
+      - nginx
+    networks:
+      internal:
+    expose:
+      - "4444"
+
+  protractor:
+    build:
+      context: .
+      dockerfile: Dockerfile.protractor
+    image: quay.io/mapstory/protractor:master
+    links:
+      - selenium
+      - nginx
+    volumes:
+      - ./mapstory/tests:/opt/mapstory/tests
+    networks:
+      internal:
+
   postgres:
     image: mdillon/postgis:9.5
     env_file:


### PR DESCRIPTION
Use docker deployment's selenium instead of Sauce if building against a fork PR because the Sauce credentials are not available.