### PR TITLE
Pin django-polymorphic to 1.3 until we upgrade to geonode 2.7.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -84,3 +84,6 @@ django-model-utils==3.0.0
 
 # Fixes slugify by bumping version to HEAD as of 2018-01-09
 git+git://github.com/dimka665/awesome-slugify@a6563949965bcddd976b7b3fb0babf76e3b490f7#egg=awesome-slugify
+
+# Temporary fix until we upgrade to Geonode 2.7.x
+django-polymorphic==1.3


### PR DESCRIPTION
Temporary fix that pins django-polymorphic until we merge in the geonode 2.7.x upgrade which already has it pinned.