### PR TITLE
Profile interests to display on profile sidebar

### DIFF
--- a/mapstory/mapstory_profile/models.py
+++ b/mapstory/mapstory_profile/models.py
@@ -70,8 +70,8 @@ class MapstoryProfile(models.Model):
         blank=True,
         null=True)
 
-    def keyword_slug_list(self):
-        return [kw.slug for kw in self.keywords.all()]
+    def interests_slug_list(self):
+        return [kw.slug for kw in self.interests.all()]
 
 def profile_post_save(instance, sender, **kwargs):
     MapstoryProfile.objects.filter(user_id=instance.id).update(

--- a/mapstory/static/mapstory/js/src/profile.controller.js
+++ b/mapstory/static/mapstory/js/src/profile.controller.js
@@ -12,6 +12,7 @@
 
   function profileController($injector, $scope, $http) {
     $scope.counts = {};
+    $scope.interestChips = interests;
 
     $scope.query = {
       owner__username__in: PROFILE_USERNAME,

--- a/mapstory/templates/people/_sidebar.html
+++ b/mapstory/templates/people/_sidebar.html
@@ -20,6 +20,13 @@
     <div class="sidebar-header"><h3>Expertise</h3></div>
     <div class="sidebar-content">{{ profile.mapstoryprofile.expertise }}</div>
 {% endif %}
+{% if interests != "[]" %}
+    <div class="sidebar-header"><h3>Interests</h3></div>
+    <md-content>
+        <md-chips ng-model="interestChips" readonly="true" md-removable="false" md-max-chips="20">
+        </md-chips>
+    </md-content>   
+{% endif %}
 {% if user.Volunteer_Technical_Community %}
     <div class="sidebar-content"><p>Volunteer Technical Community Member</p></div>
 {% endif %}
@@ -58,3 +65,8 @@ TODO: change help text in /geonode/geonode/people/models.py to encourage correct
         <button class="btn btn-danger"><a href="{% url "profile_delete" user.username %}">{% trans "delete profile" %}</a> </button>
     </div>
 {% endif %}
+
+{# storing interests from the ctx dictionary in js scope to be available in profile.controller.js for chip generation #}
+<script>
+    var interests = {{interests|safe}};
+</script>

--- a/mapstory/views.py
+++ b/mapstory/views.py
@@ -167,6 +167,7 @@ class ProfileDetail(DetailView):
         for notice in NoticeType.objects.filter(label__in=PROFILE_NOTICE_SETTINGS):
             notice_settings.append(NoticeSetting.for_user(self.object, notice, NOTICE_MEDIA[0][0]))
         ctx['notice_settings'] = notice_settings
+        ctx['interests'] = json.dumps(self.object.mapstoryprofile.interests_slug_list())
 
         return ctx
 


### PR DESCRIPTION
Closes #1145 

Here I re-used the previous keyword_slug_list from the mapstoryProfile django model and passed that into the view's context dictionary as "interests" making sure it was json compatible then used inline javascript to expose it to the client-side scope for the angular profile controller to be able to use it in the material chips directive

Up to 20 interests will display on the sidebar of a users profile under the header "Interests" if there are any interests present. If not, there is no additional information displaying on the sidebar.
