### PR TITLE
Switch to use the MapStory fork of GeoNode

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,8 +16,8 @@
 	branch = composer
 [submodule "deps/geonode"]
 	path = deps/geonode
-	url = https://github.com/GeoNode/geonode.git
-	branch = 2.6.x
+	url = https://github.com/MapStory/geonode.git
+	branch = mapstory-2.6.x
 [submodule "deps/maploom"]
 	path = deps/maploom
 	url = https://github.com/MapStory/MapLoom.git


### PR DESCRIPTION
I believe the following will be necessary to get a currently checkout out repo working:
```
git pull
rm -r deps/geonode
git submodule sync
git submodule update --init --recursive
```

It will wipe out anything in the current GeoNode submodule.