### PR TITLE
make thumbnail task be scheduled after layer is commited to DB

### DIFF
--- a/mapstory/settings/base.py
+++ b/mapstory/settings/base.py
@@ -162,7 +162,8 @@ DATABASE_PORT = '5432'
 if DATABASE_PASSWORD:
     DATABASES = {
         'default': {
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+                    # we use transaction_hooks so we can attach on_commit actions
+            'ENGINE': 'transaction_hooks.backends.postgresql_psycopg2',
             'NAME': 'mapstory',
             'USER': 'mapstory',
             'PASSWORD': DATABASE_PASSWORD,
@@ -703,4 +704,4 @@ SCHEMA_DOWNLOAD_EXCLUDE = [
 FEATURE_MULTIPLE_STORY_CHAPTERS = str_to_bool(os.environ.get('FEATURE_MULTIPLE_STORY_CHAPTERS', 'False'))
 
 # Choose thumbnail generator -- this is the delayed phantomjs generator
-THUMBNAIL_GENERATOR = "mapstory.apps.thumbnails.tasks.create_gs_thumbnail_mapstory"
+THUMBNAIL_GENERATOR = "mapstory.apps.thumbnails.tasks.create_gs_thumbnail_mapstory_tx_aware"

--- a/requirements.txt
+++ b/requirements.txt
@@ -87,3 +87,5 @@ git+git://github.com/dimka665/awesome-slugify@a6563949965bcddd976b7b3fb0babf76e3
 
 # Temporary fix until we upgrade to Geonode 2.7.x
 django-polymorphic==1.3
+
+django-transaction-hooks==0.2


### PR DESCRIPTION
This provides better scheduling between importer and the thumbnail generation.

The issue happened when there were multiple celery tasks - the importer is running as a celery task and it schedules the thumbnail generation.  Unfortunately, if there are multiple celery workers, when the thumbnail generation task is executed, the db transaction from the importer hasn't been committed.  This schedules the thumbnail task to be created after the transaction is committed.

NOTE: in django 1.9+, the added requirement (django-transaction-hooks) is already included by default in core django.