### PR TITLE
use public geoserver and retry failed tasks

### DIFF
--- a/mapstory/apps/thumbnails/tasks.py
+++ b/mapstory/apps/thumbnails/tasks.py
@@ -100,7 +100,7 @@ class CreateStoryLayerThumbnailTask(Task):
     # timepositions = list of dates (string)
     def retreive_WMS_metadata(self, layer):
         layername = layer.typename.encode('utf-8')
-        url = settings.OGC_SERVER['default']['PUBLIC_LOCATION'] + "geonode/"  # workspace is hard-coded in the importer
+        url = settings.OGC_SERVER['default']['LOCATION'] + "geonode/"  # workspace is hard-coded in the importer
         url += layername + "/wms?request=GetCapabilities&version=1.1.1"
 
         get_cap_data= self.request_geoserver_with_credentials(url)
@@ -129,7 +129,7 @@ class CreateStoryLayerThumbnailTask(Task):
     def create_phantomjs_args(self, layer, tempfname):
         boundingBoxWGS84, timepositions = self.retreive_WMS_metadata(layer)
 
-        wms = settings.OGC_SERVER['default']['PUBLIC_LOCATION'] + "geonode/wms"
+        wms = settings.OGC_SERVER['default']['LOCATION'] + "geonode/wms"
         layerName = layer.typename.encode('utf-8')
         xmin = boundingBoxWGS84[0]
         ymin = boundingBoxWGS84[1]

--- a/mapstory/apps/thumbnails/tasks.py
+++ b/mapstory/apps/thumbnails/tasks.py
@@ -60,7 +60,7 @@ class CreateStoryLayerThumbnailTask(Task):
     def has_features(self, layer):
         layername = layer.typename.encode('utf-8')
 
-        url = settings.OGC_SERVER['default']['LOCATION'] + "geonode/"  # workspace is hard-coded in the importer
+        url = settings.OGC_SERVER['default']['PUBLIC_LOCATION'] + "geonode/"  # workspace is hard-coded in the importer
         url += layername + "/wfs?request=GetFeature&maxfeatures=1&request=GetFeature&typename=geonode%3A" + layername + "&version=1.1.0"
 
         feats = urllib2.urlopen(url).read()
@@ -76,7 +76,7 @@ class CreateStoryLayerThumbnailTask(Task):
     def retreive_WMS_metadata(self, layer):
         layername = layer.typename.encode('utf-8')
         url = settings.OGC_SERVER['default'][
-                  'LOCATION'] + "geonode/" + layername + "/wms"  # workspace is hard-coded in the importer
+                  'PUBLIC_LOCATION'] + "geonode/" + layername + "/wms"  # workspace is hard-coded in the importer
         url += "?request=GetCapabilities&version=1.1.1"
         wms = WebMapService(url)
 
@@ -229,7 +229,7 @@ class CreateStoryLayerThumbnailTask(Task):
             print "EXCEPTION - thumbnail generation"
             print(e)
             print traceback.format_exc()
-            raise
+            self.retry(max_retries=5, countdown=5) # retry in 5 seconds
 
 # convenience method (used by geonode) to start (via celery) the
 # thumbnail generation task.

--- a/mapstory/apps/thumbnails/tasks.py
+++ b/mapstory/apps/thumbnails/tasks.py
@@ -75,7 +75,7 @@ class CreateStoryLayerThumbnailTask(Task):
     # timepositions = list of dates (string)
     def retreive_WMS_metadata(self, layer):
         layername = layer.typename.encode('utf-8')
-        url = settings.OGC_SERVER['default']['PUBLIC_LOCATION'] + "geonode/"    # workspace is hard-coded in the importer
+        url = settings.OGC_SERVER['default']['PUBLIC_LOCATION'] + "geonode/"  # workspace is hard-coded in the importer
         url += layername + "/wms?request=GetCapabilities&version=1.1.1"
 
         get_cap_data = urllib2.urlopen(url).read()

--- a/mapstory/apps/thumbnails/tasks.py
+++ b/mapstory/apps/thumbnails/tasks.py
@@ -75,10 +75,11 @@ class CreateStoryLayerThumbnailTask(Task):
     # timepositions = list of dates (string)
     def retreive_WMS_metadata(self, layer):
         layername = layer.typename.encode('utf-8')
-        url = settings.OGC_SERVER['default'][
-                  'PUBLIC_LOCATION'] + "geonode/" + layername + "/wms"  # workspace is hard-coded in the importer
-        url += "?request=GetCapabilities&version=1.1.1"
-        wms = WebMapService(url)
+        url = settings.OGC_SERVER['default']['PUBLIC_LOCATION'] + "geonode/"    # workspace is hard-coded in the importer
+        url += layername + "/wms?request=GetCapabilities&version=1.1.1"
+
+        get_cap_data = urllib2.urlopen(url).read()
+        wms = WebMapService(url, xml=get_cap_data)
 
         # I found that some dataset advertise illegal bounds - fix them up
         xmin = wms[layername].boundingBoxWGS84[0]


### PR DESCRIPTION
There seems to be a problem with the private (geoserver:8080) geoserver, but not with the public (staging.mapstory.org) geoserver.  This is set to use the public one.
NOTE: either should be working

Also, re-try the task after 2 second (max 5 re-tries) if there's a problem.