### PR TITLE
add better handling of super()

### DIFF
--- a/mapstory/apps/thumbnails/tasks.py
+++ b/mapstory/apps/thumbnails/tasks.py
@@ -296,7 +296,7 @@ class CreateStoryLayerAnimatedThumbnailTask(CreateStoryLayerThumbnailTask):
         finally:
             os.remove(gif_fname)  # clean up
 
-    # overwrite from non-animated class
+    # override from non-animated class
     #
     # for each timeslice
     #     create a image for it
@@ -306,7 +306,7 @@ class CreateStoryLayerAnimatedThumbnailTask(CreateStoryLayerThumbnailTask):
     def create_screenshot(self, layer):
         boundingBoxWGS84, timepositions = self.retreive_WMS_metadata(layer)
         if timepositions is None or len(timepositions) == 1:  # cannot animate, call parent implementation
-            return super(CreateStoryLayerAnimatedThumbnailTask, self).create_screenshot(layer)
+            return CreateStoryLayerThumbnailTask.create_screenshot(self,layer)
 
         try:
             frame_fnames = []

--- a/mapstory/apps/thumbnails/test_storylayer_thumbnail.py
+++ b/mapstory/apps/thumbnails/test_storylayer_thumbnail.py
@@ -135,6 +135,18 @@ class TestAnimatedStoryLayerThumbnailTask(GeoGigUploaderBase, TestCase):
         self.assertTrue(image.is_animated)
         self.assertEqual(image.n_frames, 10)
 
+    # test an empty layer -- this will not be animated
+    def test_empty_layer(self):
+        layer = self.fully_import_file(os.path.realpath('mapstory/tests/sampledata/'), 'empty_layer.zip', 'date')
+        thumb_generator = CreateStoryLayerAnimatedThumbnailTask()
+
+        imageData = thumb_generator.create_screenshot(layer)
+        image_file = StringIO(imageData)
+        image = Image.open(image_file)
+
+        self.assertEqual(image.format, "PNG") # not a GIF
+
+
 
 # ------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Noticed (on staging) there was an issue with a super() call.  I think this is likely due to module reloading (perhaps by django or perhaps because of how the plugin system work).  This makes the super() call more explicit.

Added test case for non-animatable situation.  

NOTE: test case does not test actual problem on staging - I was unable to reproduce locally.