### PR TITLE
Update Mapstories API Filtering

### DIFF
--- a/mapstory/api/resourcebase_api.py
+++ b/mapstory/api/resourcebase_api.py
@@ -542,7 +542,10 @@ class MapStoryResource(CommonModelApi):
         if settings.RESOURCE_PUBLISHING:
             queryset = queryset.filter(is_published=True)
         resource_name = 'mapstories'
-
+        filtering = {
+            'id': ALL,
+            'slug': ALL
+        }
 
 class MapResource(CommonModelApi):
 


### PR DESCRIPTION
Allows you to filter the mapstories API by either id or slug by using ?id= or ?slug= at the end of the route.