### PR TITLE
Add git attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Ensure that .sh files use LF line endings.  
+.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,4 @@
 * text=auto
 
 # Ensure that .sh files use LF line endings.  
-.sh text eol=lf
+*.sh text eol=lf


### PR DESCRIPTION
Line endings are causing issues on Windows machines - this should ensure that all shell scripts are checked out as LF line endings so that docker can run them.