### PR TITLE
handle no-background story thumbnails

### DIFF
--- a/mapstory/apps/thumbnails/static/thumbnails/static/thumbnail_storylayer.html
+++ b/mapstory/apps/thumbnails/static/thumbnails/static/thumbnail_storylayer.html
@@ -86,7 +86,10 @@
         document.getElementById("map").style.height = map_height + "px";
 
         // setup layers
-         var layers = [create_XYZ_layer(basemapXYZURL)]; //basemap
+        var layers=[];
+        if (basemapXYZURL != "None")
+           layers = [create_XYZ_layer(basemapXYZURL)]; //basemap
+
         for (t=0;t<layerNames_list.length;t++) {
             var layer =  create_WMS_layer(wms, layerNames_list[t],styles_list[t], time_bounds_list[t]);
             layers.push(layer);


### PR DESCRIPTION
If there is no basemap XYZ server url, then dont add the layer to the OL map.