### PR TITLE
add caching headers to nginx for thumbnails (uploads dir)

### DIFF
--- a/docker/nginx/templates/nginx.conf.ctmpl
+++ b/docker/nginx/templates/nginx.conf.ctmpl
@@ -61,6 +61,8 @@ http {
     # serve mediafiles, default 'uploaded' in GeoNode
     location /uploaded/ {
       alias {{ env "MEDIA_ROOT" }}/;
+      add_header Cache-Control "max-age: 0, must-revalidate";
+      etag on;
     }
 
     # geoserver proxy


### PR DESCRIPTION
This will enable the ETag/If-None-Match cache validation for the uploads directory (where the thumbnails are stored)