### PR TITLE
support mapbox tiles with no z=0 layer

### DIFF
--- a/mapstory/apps/thumbnails/static/thumbnails/static/thumbnail_storylayer.html
+++ b/mapstory/apps/thumbnails/static/thumbnails/static/thumbnail_storylayer.html
@@ -151,6 +151,7 @@
             source: new ol.source.XYZ({
                 crossOrigin: null,
                 opaque: true,
+                minZoom: 1, //some mapbox layer don't have Z=0
                 maxZoom: 19,
                 url: options_url,
                 transition: 0


### PR DESCRIPTION
Some mapbox servers do not have a Z=0 (esp world-dark).  This limits the map to display Z1 or high resolution (never asks for Z=0)