### PR TITLE
add better caching for chrome img tags

### DIFF
--- a/docker/nginx/templates/nginx.conf.ctmpl
+++ b/docker/nginx/templates/nginx.conf.ctmpl
@@ -62,6 +62,7 @@ http {
     location /uploaded/ {
       alias {{ env "MEDIA_ROOT" }}/;
       add_header Cache-Control "max-age: 0, must-revalidate";
+      add_header Last-Modified "";
       etag on;
     }
 


### PR DESCRIPTION
This isn't needed in Firefox, but needed for Chrome.