### PR TITLE
Adds environment variable ADMIN_EMAIL and replaces

### DIFF
--- a/docker/env/dev/mapstory.env
+++ b/docker/env/dev/mapstory.env
@@ -21,3 +21,5 @@ RABBITMQ_APPLICATION_VHOST=mapstory
 
 # Feature Toggles
 FEATURE_MULTIPLE_STORY_CHAPTERS=True
+
+ADMIN_EMAIL=info@mapstory.org

--- a/docker/env/lab/mapstory.env
+++ b/docker/env/lab/mapstory.env
@@ -35,3 +35,5 @@ RABBITMQ_HOST=rabbitmq
 
 # Feature Toggles
 FEATURE_MULTIPLE_STORY_CHAPTERS=True
+
+ADMIN_EMAIL=info@mapstory.org

--- a/docker/env/prod/mapstory.env
+++ b/docker/env/prod/mapstory.env
@@ -52,3 +52,5 @@ RABBITMQ_HOST=rabbitmq
 # RABBITMQ_APPLICATION_VHOST=
 
 USER_SNAP=True
+
+ADMIN_EMAIL=info@mapstory.org

--- a/docker/env/staging/mapstory.env
+++ b/docker/env/staging/mapstory.env
@@ -39,3 +39,5 @@ RABBITMQ_HOST=rabbitmq
 # RABBITMQ_APPLICATION_VHOST=
 
 USER_SNAP=True
+
+ADMIN_EMAIL=info@mapstory.org

--- a/docker/env/storyscapes/mapstory.env
+++ b/docker/env/storyscapes/mapstory.env
@@ -43,3 +43,5 @@ FEATURE_MULTIPLE_STORY_CHAPTERS=True
 # Audit Logging
 AUDIT_ENABLED=True
 AUDIT_TO_FILE=True
+
+ADMIN_EMAIL=GEOINTServicesOperations@nga.mil

--- a/mapstory/context_processors.py
+++ b/mapstory/context_processors.py
@@ -32,5 +32,6 @@ def context(req):
         default_append_config=json.dumps(append_config),
         default_layer_config=json.dumps(default_config),
         favorite_info=get_favorite_info(req),
-        site=Site.objects.get_current()
+        site=Site.objects.get_current(),
+        ADMIN_EMAIL=getattr(settings, 'ADMIN_EMAIL', "")
     )

--- a/mapstory/context_processors.py
+++ b/mapstory/context_processors.py
@@ -33,5 +33,5 @@ def context(req):
         default_layer_config=json.dumps(default_config),
         favorite_info=get_favorite_info(req),
         site=Site.objects.get_current(),
-        ADMIN_EMAIL=getattr(settings, 'ADMIN_EMAIL', "")
+        ADMIN_EMAIL=getattr(settings, 'ADMIN_EMAIL', '')
     )

--- a/mapstory/settings/base.py
+++ b/mapstory/settings/base.py
@@ -77,6 +77,7 @@ BRANDING_STORIES_NAME = os.environ.get('BRANDING_STORIES_NAME', 'MapStories')
 BRANDING_LAYER_NAME = os.environ.get('BRANDING_LAYER_NAME', 'StoryLayer')
 BRANDING_LAYERS_NAME = os.environ.get('BRANDING_LAYERS_NAME', 'StoryLayers')
 THEME = os.environ.get('THEME', 'default')
+ADMIN_EMAIL = os.environ.get('ADMIN_EMAIL', '')
 
 # Misc
 ACCOUNT_OPEN_SIGNUP = str_to_bool(os.environ.get('REGISTRATION_OPEN', 'True'))

--- a/mapstory/templates/people/profile_delete.html
+++ b/mapstory/templates/people/profile_delete.html
@@ -13,12 +13,9 @@
     <p>If you would like to deactivate your profile, untick the box below. You will not be able to use your account once deactivated. To reactivate, please email info@mapstory.org.</p>
         <p>Note that the deactivation of a profile does not remove the content that was uploaded with this profile. If you wish to remove content, you may do so manually on your <a href="{% url "profile_detail" slug=user.username %}">profile page.</a> Otherwise, to have your profile completely deleted, you must <a href="mailto:info@mapstory.org">contact an administrator.</a></p>
     {% else %}
-    <!-- TODO: Place admin email here: -->
-    <p>If you would like to deactivate your profile, untick the box below. You will not be able to use your account once deactivated. To reactivate, please email [admin email goes here].</p>
-    <p>Note that the deactivation of a profile does not remove the content that was uploaded with this profile. If you wish to remove content, you may do so manually on your <a href="{% url "profile_detail" slug=user.username %}">profile page.</a> Otherwise, to have your profile completely deleted, you must <a href="#">contact an administrator.</a></p>
+    <p>If you would like to deactivate your profile, untick the box below. You will not be able to use your account once deactivated. To reactivate, please email GEOINTServicesOperations@nga.mil".</p>
+    <p>Note that the deactivation of a profile does not remove the content that was uploaded with this profile. If you wish to remove content, you may do so manually on your <a href="{% url "profile_detail" slug=user.username %}">profile page.</a> Otherwise, to have your profile completely deleted, you must <a href="GEOINTServicesOperations@nga.mil">contact an administrator.</a></p>
     {% endif %}
-
-
     <form action="" method="post" class="form-horizontal">
       {% csrf_token %}
       <div class="form-controls">

--- a/mapstory/templates/people/profile_delete.html
+++ b/mapstory/templates/people/profile_delete.html
@@ -9,9 +9,15 @@
     <h2 class="page-title">{% trans "Delete Your Profile" %}</h2>
   </div>
   <div class="col-md-12">
+    {% if THEME == 'orange' %}
     <p>If you would like to deactivate your profile, untick the box below. You will not be able to use your account once deactivated. To reactivate, please email info@mapstory.org.</p>
+        <p>Note that the deactivation of a profile does not remove the content that was uploaded with this profile. If you wish to remove content, you may do so manually on your <a href="{% url "profile_detail" slug=user.username %}">profile page.</a> Otherwise, to have your profile completely deleted, you must <a href="mailto:info@mapstory.org">contact an administrator.</a></p>
+    {% else %}
+    <!-- TODO: Place admin email here: -->
+    <p>If you would like to deactivate your profile, untick the box below. You will not be able to use your account once deactivated. To reactivate, please email [admin email goes here].</p>
+    <p>Note that the deactivation of a profile does not remove the content that was uploaded with this profile. If you wish to remove content, you may do so manually on your <a href="{% url "profile_detail" slug=user.username %}">profile page.</a> Otherwise, to have your profile completely deleted, you must <a href="#">contact an administrator.</a></p>
+    {% endif %}
 
-    <p>Note that the deactivation of a profile does not remove the content that was uploaded with this profile. If you wish to remove content, you may do so manually on your <a href="{% url "profile_detail" slug=user.username %}">profile page.</a> Otherwise, to have your profile completely deleted, you must <a href="mailto:info@mapstory.org">contact an administrator.</a></p>
 
     <form action="" method="post" class="form-horizontal">
       {% csrf_token %}

--- a/mapstory/templates/people/profile_delete.html
+++ b/mapstory/templates/people/profile_delete.html
@@ -9,13 +9,8 @@
     <h2 class="page-title">{% trans "Delete Your Profile" %}</h2>
   </div>
   <div class="col-md-12">
-    {% if THEME == 'orange' %}
-    <p>If you would like to deactivate your profile, untick the box below. You will not be able to use your account once deactivated. To reactivate, please email info@mapstory.org.</p>
-        <p>Note that the deactivation of a profile does not remove the content that was uploaded with this profile. If you wish to remove content, you may do so manually on your <a href="{% url "profile_detail" slug=user.username %}">profile page.</a> Otherwise, to have your profile completely deleted, you must <a href="mailto:info@mapstory.org">contact an administrator.</a></p>
-    {% else %}
-    <p>If you would like to deactivate your profile, untick the box below. You will not be able to use your account once deactivated. To reactivate, please email GEOINTServicesOperations@nga.mil".</p>
-    <p>Note that the deactivation of a profile does not remove the content that was uploaded with this profile. If you wish to remove content, you may do so manually on your <a href="{% url "profile_detail" slug=user.username %}">profile page.</a> Otherwise, to have your profile completely deleted, you must <a href="GEOINTServicesOperations@nga.mil">contact an administrator.</a></p>
-    {% endif %}
+    <p>If you would like to deactivate your profile, untick the box below. You will not be able to use your account once deactivated. To reactivate, please email {{ ADMIN_EMAIL }}.</p>
+        <p>Note that the deactivation of a profile does not remove the content that was uploaded with this profile. If you wish to remove content, you may do so manually on your <a href="{% url "profile_detail" slug=user.username %}">profile page.</a> Otherwise, to have your profile completely deleted, you must <a href="mailto:{{ ADMIN_EMAIL }}">contact an administrator.</a></p>
     <form action="" method="post" class="form-horizontal">
       {% csrf_token %}
       <div class="form-controls">


### PR DESCRIPTION
- ~~Removed references to admin email when theme is not orange.~~
- Added environment variable `ADMIN_EMAIL` that defaults to `""`
- NOTE:  if ADMIN_EMAIL is not set, emailing admin will not work.
- Changed the email reference to use the value inside ADMIN_EMAIL


DO NOT FORGET TO SET `ADMIN_EMAIL`!!! 