### PR TITLE
Fix thumbnails for GeoNode 2.8 upgrade

### DIFF
--- a/mapstory/apps/thumbnails/tasks.py
+++ b/mapstory/apps/thumbnails/tasks.py
@@ -281,7 +281,7 @@ class CreateStoryLayerThumbnailTask:
             print "EXCEPTION - thumbnail generation for layer pk="+str(pk)
             print(e)
             print traceback.format_exc()
-
+            raise e # send forward so actual task can retry()
 
 
 # ------------------------------------------------------------------------------------------------------------
@@ -545,6 +545,7 @@ class CreateStoryAnimatedThumbnailTask(CreateStoryLayerAnimatedThumbnailTask):
             print "EXCEPTION - thumbnail generation for story pk=" + str(pk)
             print(e)
             print traceback.format_exc()
+            raise e # send forward so actual task can retry()
 
 
 ############################################################################################

--- a/mapstory/apps/thumbnails/tasks.py
+++ b/mapstory/apps/thumbnails/tasks.py
@@ -30,7 +30,7 @@ import datetime
 def decodeTypeName(typename):
     result = typename.split(":")
     if len(result)==1:
-        return "geonode",result
+        return "geonode",result[0]
     return result
 
 # Celery-compatible task to create thumbnails using PhantomJS

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ django-autocomplete-light==2.3.3
 django-model-utils==3.0.0
 elasticsearch==1.6.0
 lxml==3.6.2
+Pillow==5.1.0


### PR DESCRIPTION
1. Update to Pillow 5.1.0 (requirements.txt) - required for animated gif
2. accept layername in workspace:layer format 
3. move from Class-base celery tasks to Method-based celery tasks
