### PR TITLE
Fix some of the share urls on the layer detail page

### DIFF
--- a/mapstory/templates/layers/_details.html
+++ b/mapstory/templates/layers/_details.html
@@ -15,7 +15,7 @@
             <div class="row">
                 <div style="text-align: left">
                     <div>
-                        <h2>{{resource.title}} 
+                        <h2>{{resource.title}}
                         {% if not resource.is_published %}
                             <a href="#metaForm" data-toggle="modal" class="btn btn-danger">
                                 <i class="fa fa-lock"></i> Private
@@ -96,7 +96,7 @@
                                                     var loggedIn = "{{user.is_authenticated}}";
                                                 </script>
                                                 <md-content class="md-padding" layout="column">
-                                                    <md-chips ng-model="chips" 
+                                                    <md-chips ng-model="chips"
                                                     readonly="readOnly"
                                                     md-on-add="addTag($chip)"
                                                     md-on-remove="removeTag($chip)"

--- a/mapstory/templates/layers/_details.html
+++ b/mapstory/templates/layers/_details.html
@@ -176,7 +176,7 @@
                                         <i class="fa fa-question-circle ng-scope">
                                             <md-tooltip>OpenGIS® Web Map Service Interface Standard</md-tooltip>
                                         </i>
-                                        <input id="shareWMS" value ="https://{{ request.get_host }}/geoserver/geonode/{{ resource }}/wms?REQUEST=GetCapabilities&SERVICE=WMS&TILED=true&VERSION=1.1.1">
+                                        <input id="shareWMS" value ="https://{{ request.get_host }}/geoserver/geonode/{{ resource.name }}/wms?REQUEST=GetCapabilities&SERVICE=WMS&TILED=true&VERSION=1.1.1">
 
                                         <button class="copyclip btn" data-clipboard-target="#shareWMS">
                                             <i class="fa fa-clipboard" aria-hidden="true"></i>
@@ -186,7 +186,7 @@
                                         <i class="fa fa-question-circle ng-scope">
                                             <md-tooltip>OGC® Web Feature Service</md-tooltip>
                                         </i>
-                                        <input id="shareWFS" value ="https://{{ request.get_host }}/geoserver/geonode/{{ resource }}/wfs?REQUEST=GetCapabilities&SERVICE=WFS&VERSION=2.0.0">
+                                        <input id="shareWFS" value ="https://{{ request.get_host }}/geoserver/geonode/{{ resource.name }}/wfs?REQUEST=GetCapabilities&SERVICE=WFS&VERSION=2.0.0">
 
                                         <button class="copyclip btn" data-clipboard-target="#shareWFS">
                                             <i class="fa fa-clipboard" aria-hidden="true"></i>

--- a/mapstory/templates/layers/_details.html
+++ b/mapstory/templates/layers/_details.html
@@ -176,7 +176,9 @@
                                         <i class="fa fa-question-circle ng-scope">
                                             <md-tooltip>OpenGIS® Web Map Service Interface Standard</md-tooltip>
                                         </i>
-                                        <input id="shareWMS" value ="https://{{ request.get_host }}/geoserver/geonode/{{ resource.name }}/wms?REQUEST=GetCapabilities&SERVICE=WMS&TILED=true&VERSION=1.1.1">
+                                        <input id="shareWMS"
+                                               aria-label="WMS"
+                                               value ="https://{{ request.get_host }}/geoserver/geonode/{{ resource.name }}/wms?REQUEST=GetCapabilities&SERVICE=WMS&TILED=true&VERSION=1.1.1">
 
                                         <button class="copyclip btn" data-clipboard-target="#shareWMS">
                                             <i class="fa fa-clipboard" aria-hidden="true"></i>
@@ -186,7 +188,9 @@
                                         <i class="fa fa-question-circle ng-scope">
                                             <md-tooltip>OGC® Web Feature Service</md-tooltip>
                                         </i>
-                                        <input id="shareWFS" value ="https://{{ request.get_host }}/geoserver/geonode/{{ resource.name }}/wfs?REQUEST=GetCapabilities&SERVICE=WFS&VERSION=2.0.0">
+                                        <input id="shareWFS"
+                                               aria-label="WFS"
+                                               value ="https://{{ request.get_host }}/geoserver/geonode/{{ resource.name }}/wfs?REQUEST=GetCapabilities&SERVICE=WFS&VERSION=2.0.0">
 
                                         <button class="copyclip btn" data-clipboard-target="#shareWFS">
                                             <i class="fa fa-clipboard" aria-hidden="true"></i>
@@ -194,7 +198,8 @@
                                     </div>
                                     <div class="embed"> Embed
                                         <input id="embedLayer"
-                                               value="<iframe style='border: none;' height='400' width='600' src='https://{{ request.get_host }}/layers/{{ resource.service_typename }}/embed'></iframe>"/>
+                                               aria-label="Embed"
+                                               value="<iframe style='border: none;' height='400' width='600' src='https://{{ request.get_host }}/layers/{{ resource.service_typename }}/embed'></iframe>">
                                         <button class="copyclip btn" data-clipboard-target="#embedLayer">
                                             <i class="fa fa-clipboard" aria-hidden="true"></i>
                                         </button>

--- a/mapstory/views.py
+++ b/mapstory/views.py
@@ -1076,7 +1076,7 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
     thumbnail = layer.get_thumbnail_url
 
     # This will get URL encoded later and is used for the social media share URL
-    share_url = "https://%s/layers/%s" % (request.get_host(), layer.name)
+    share_url = "https://%s/layers/%s" % (request.get_host(), layer.typename)
     share_title = "%s by %s." % (layer.title, layer.owner)
     share_description = layer.abstract
 


### PR DESCRIPTION
I'm not particularly happy with the way this works, but it seems to fix several of the URLs for sharing layers.