### PR TITLE
Custom StoryScapes Registration Path

### DIFF
--- a/mapstory/settings/base.py
+++ b/mapstory/settings/base.py
@@ -179,7 +179,7 @@ TEMPLATES = [
 #
 # Authentication Settings
 #
-ACCOUNT_ADAPTER = 'mapstory.views.CustomAccountAdapter'
+ACCOUNT_ADAPTER = os.environ.get('ACCOUNT_ADAPTER', 'mapstory.views.MapStoryAccountAdapter')
 ACCOUNT_FORMS = {'signup': 'mapstory.forms.CustomSignupForm'}
 
 AUTHENTICATION_BACKENDS = (

--- a/mapstory/views.py
+++ b/mapstory/views.py
@@ -110,10 +110,16 @@ class IndexView(TemplateView):
 
         return ctx
 
-class CustomAccountAdapter(DefaultAccountAdapter):
+class MapStoryAccountAdapter(DefaultAccountAdapter):
 
     def get_login_redirect_url(self, request):
         path = "/storyteller/edit/{username}/"
+        return path.format(username=request.user.username)
+
+class StoryScapesAccountAdapter(DefaultAccountAdapter):
+
+    def get_login_redirect_url(self, request):
+        path = "/"
         return path.format(username=request.user.username)
 
 class GetPageView(DetailView):


### PR DESCRIPTION
Creates a customAccountAdapter for StoryScapes and allows you to use an environment variable to choose to use it.  StoryScapes deploys should set the ACCOUNT_ADAPTER environment variable to mapstory.views.StoryScapesAccountAdapter