### PR TITLE
Configurable basemaps

### DIFF
--- a/mapstory/admin.py
+++ b/mapstory/admin.py
@@ -6,7 +6,7 @@ from geonode.layers.models import Layer
 from geonode.people.admin import ProfileAdmin as UserAdmin
 from mapstory.export import export_via_model
 from mapstory.flag import admin as flag_admin
-from mapstory.models import (Baselayer, CustomSite, DefaultBaselayer,
+from mapstory.models import (Baselayer, BaselayerDefault, CustomSite,
                              GetPage, GetPageContent, Leader,
                              MapStory, NewsItem, ParallaxImage, Sponsor)
 
@@ -162,11 +162,19 @@ class BaselayerAdmin(admin.ModelAdmin):
     model = Baselayer
 
 
-class DefaultBaselayerAdmin(admin.ModelAdmin):
-    class Meta:
-        verbose_name = 'Default Baselayer'
-        verbose_name_plural = 'Default Baselayer'
-    model = DefaultBaselayer
+class BaselayerDefaultAdmin(admin.ModelAdmin):
+    def get_actions(self, request):
+        actions = super(BaselayerDefaultAdmin, self).get_actions(request)
+        del actions['delete_selected']
+        return actions
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    model = BaselayerDefault
 
 
 admin.site.unregister(Layer)
@@ -180,4 +188,4 @@ admin.site.register(Leader, LeaderAdmin)
 admin.site.register(ParallaxImage, ParallaxImageAdmin)
 admin.site.register(CustomSite, CustomSiteAdmin)
 admin.site.register(Baselayer, BaselayerAdmin)
-admin.site.register(DefaultBaselayer, DefaultBaselayerAdmin)
+admin.site.register(BaselayerDefault, BaselayerDefaultAdmin)

--- a/mapstory/fixtures/initial_baselayers.json
+++ b/mapstory/fixtures/initial_baselayers.json
@@ -256,7 +256,7 @@
     "fields": {
       "layer": 10
     },
-    "model": "mapstory.defaultbaselayer",
+    "model": "mapstory.baselayerdefault",
     "pk": 1
   }
 ]

--- a/mapstory/fixtures/initial_baselayers_geoint.json
+++ b/mapstory/fixtures/initial_baselayers_geoint.json
@@ -49,7 +49,7 @@
     "fields": {
       "layer": 1
     },
-    "model": "mapstory.defaultbaselayer",
+    "model": "mapstory.baselayerdefault",
     "pk": 1
   }
 ]

--- a/mapstory/mapstories/urls.py
+++ b/mapstory/mapstories/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 
 from geonode.maps.views import new_map
 
-from .views import (composer_new_view, delete_mapstory, map_detail,
+from .views import (composer_new_view, composer_view, delete_mapstory, map_detail,
                     mapstory_view, save_mapstory, story_generate_thumbnail, style_view)
 
 urlpatterns = [
@@ -27,7 +27,7 @@ urlpatterns = [
 
     # Composer
     url(r'^story/(?P<slug>[-\w]+)/draft$',
-        composer_new_view, {'template': 'composer_new/composer.html'}, name='composer-view'),
-    url(r'^story/new$', new_map,
+        composer_view, {'template': 'composer_new/composer.html'}, name='composer-view'),
+    url(r'^story/new$', composer_new_view,
         {'template': 'composer_new/composer.html'}, name='new-story'),
 ]

--- a/mapstory/mapstories/views.py
+++ b/mapstory/mapstories/views.py
@@ -26,7 +26,7 @@ from guardian.shortcuts import get_perms
 from mapstory.favorite.utils import get_favorite_info
 from mapstory.forms import KeywordsForm, PublishStatusForm
 from mapstory.initiatives.models import InitiativeMembership
-from mapstory.models import Baselayer, DefaultBaselayer
+from mapstory.models import Baselayer, BaselayerDefault
 from mapstory.organizations.models import (OrganizationMapStory,
                                            OrganizationMembership)
 from mapstory.search.utils import update_es_index
@@ -167,7 +167,7 @@ def mapstory_view(request, slug, snapshot=None, template='composer_new/composer.
 
     config['about']['detail_url'] = slug
 
-    layers = json.dumps({"defaultLayer": DefaultBaselayer.objects.first().layer.name,
+    layers = json.dumps({"defaultLayer": BaselayerDefault.objects.first().layer.name,
                                     "layers":  map(lambda x: x.to_object(), Baselayer.objects.all())})
 
     return render_to_response(template, RequestContext(request, {
@@ -217,7 +217,7 @@ def story_generate_thumbnail(request, storyid):
 
 def composer_new_view(request, template='composer_new/composer.html'):
     map_obj, config = new_map_config(request)
-    layers = json.dumps({"defaultLayer": DefaultBaselayer.objects.first().layer.name,
+    layers = json.dumps({"defaultLayer": BaselayerDefault.objects.first().layer.name,
                                     "layers":  map(lambda x: x.to_object(), Baselayer.objects.all())})
 
     return render_to_response(template, RequestContext(request, {
@@ -231,7 +231,7 @@ def composer_view(request, slug, template='composer_new/composer.html'):
         request, slug, 'base.change_resourcebase', _PERMISSION_MSG_SAVE)
     config = story_obj.viewer_json(request)
 
-    layers = json.dumps({"defaultLayer": DefaultBaselayer.objects.first().layer.name,
+    layers = json.dumps({"defaultLayer": BaselayerDefault.objects.first().layer.name,
                                     "layers":  map(lambda x: x.to_object(), Baselayer.objects.all())})
 
     return render_to_response(template, RequestContext(request, {

--- a/mapstory/migrations/0004_auto_20181212_2030.py
+++ b/mapstory/migrations/0004_auto_20181212_2030.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mapstory', '0003_baselayer_defaultbaselayer'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='BaselayerDefault',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('layer', models.OneToOneField(to='mapstory.Baselayer')),
+            ],
+        ),
+        migrations.RemoveField(
+            model_name='defaultbaselayer',
+            name='layer',
+        ),
+        migrations.DeleteModel(
+            name='DefaultBaselayer',
+        ),
+    ]

--- a/mapstory/models.py
+++ b/mapstory/models.py
@@ -187,7 +187,7 @@ class Baselayer(db.models.Model):
             "title": string_or_none(self.title),
             "visibility": self.visibility,
             "fixed": self.fixed,
-            "group": string_or_none(self.fixed),
+            "group": string_or_none(self.group),
             "isVirtualService": self.is_virtual_service,
             "alwaysAnonymous": self.always_anonymous,
             "proj": string_or_none(self.proj),

--- a/mapstory/models.py
+++ b/mapstory/models.py
@@ -219,12 +219,11 @@ class Baselayer(db.models.Model):
     opacity = db.models.DecimalField(default=1, max_digits=3, decimal_places=2)
 
 
-class DefaultBaselayer(db.models.Model):
+class BaselayerDefault(db.models.Model):
     def __str__(self):
         return self.layer.name
 
-    layer = db.models.OneToOneField(Baselayer, on_delete=db.models.CASCADE, primary_key=True)
-
+    layer = db.models.OneToOneField(Baselayer, on_delete=db.models.CASCADE, primary_key=False)
 
 def get_images():
     return ParallaxImage.objects.all()

--- a/mapstory/settings/base.py
+++ b/mapstory/settings/base.py
@@ -28,7 +28,6 @@ import sys
 import geonode
 import pyproj
 from geonode.settings import *
-# from mapstory.models import Baselayer, DefaultBaselayer
 
 
 def str_to_bool(v):

--- a/mapstory/templates/composer_new/composer.html
+++ b/mapstory/templates/composer_new/composer.html
@@ -21,6 +21,7 @@
       localGeoServerBaseUrl: "{{ GEOSERVER_BASE_URL }}",
       localCSWBaseUrl: "{{ CATALOGUE_BASE_URL }}",
       csrfToken: "{{ csrf_token }}",
+      baselayersConfig: {{ layers | safe }}
     }
     window.mapstory.composer.config.branding = {
       siteName: "{{ SITE_NAME }}",

--- a/mapstory/thumbnails/tasks.py
+++ b/mapstory/thumbnails/tasks.py
@@ -21,7 +21,7 @@ from geonode.layers.utils import create_gs_thumbnail_geonode
 ############################################################################################
 from mapstory.celery import app
 from mapstory.mapstories.models import Map, MapStory
-from mapstory.models import Baselayer, DefaultBaselayer
+from mapstory.models import Baselayer, BaselayerDefault
 
 # geonode:layer -> geonode,layer
 # layer -> geonode,layer (geonode workspace assumed)
@@ -176,7 +176,7 @@ class CreateStoryLayerThumbnailTask:
 
     # phantomJSFile htmlFile wms layerName xmin ymin xmax ymax time output.fname
     def create_phantomjs_args(self, typeName, boundingBoxWGS84, tempfname, time="ALL",
-                              basemapXYZURL=tileURLFromLayerName.__func__(DefaultBaselayer.objects.first().layer.name),
+                              basemapXYZURL=tileURLFromLayerName.__func__(BaselayerDefault.objects.first().layer.name),
                               styles=""):
 
         workspace, layername = decodeTypeName(typeName)

--- a/mapstory/thumbnails/test_storylayer_thumbnail.py
+++ b/mapstory/thumbnails/test_storylayer_thumbnail.py
@@ -15,7 +15,7 @@ from mapstory.tests.integration.geogig_uploader import GeoGigUploaderBase
 from mapstory.thumbnails.tasks import (CreateStoryAnimatedThumbnailTask,
                                        CreateStoryLayerAnimatedThumbnailTask,
                                        CreateStoryLayerThumbnailTask)
-from mapstory.models import Baselayer, DefaultBaselayer
+from mapstory.models import Baselayer, BaselayerDefault
 
 
 def compare_images(img1, img2, rgb_difference=1):
@@ -78,7 +78,7 @@ class TestAStoryThumbnailTask(GeoGigUploaderBase, TestCase):
             Baselayer(name="mapnik", args="[\"OpenStreetMap\"]", source_ptype="gxp_osmsource").save()
             Baselayer(name="hot", source_ptype="gxp_osmsource", args= "[\"Humanitarian OpenStreetMap\", [\"//a.tile.openstreetmap.fr/hot/${z}/${x}/${y}.png\",\"//b.tile.openstreetmap.fr/hot/${z}/${x}/${y}.png\",\"//c.tile.openstreetmap.fr/hot/${z}/${x}/${y}.png\"], {\"tileOptions\": {\"crossOriginKeyword\": None}}]").save()
             Baselayer(name="geography-class", source_ptype="gxp_mapboxsource").save()
-            DefaultBaselayer(layer=layer).save()
+            BaselayerDefault(layer=layer).save()
         GeoGigUploaderBase.setUp(self)
 
     # make a Mapstory object, with basemap layer

--- a/mapstory/views.py
+++ b/mapstory/views.py
@@ -7,7 +7,7 @@ from django.views.generic.list import ListView
 
 from geonode.base.models import Region
 from mapstory.journal.models import JournalEntry
-from mapstory.models import Baselayer, DefaultBaselayer, GetPage, Leader, NewsItem, get_images, get_sponsors
+from mapstory.models import Baselayer, BaselayerDefault, GetPage, Leader, NewsItem, get_images, get_sponsors
 from django.http import HttpResponse
 
 
@@ -48,5 +48,5 @@ class LeaderListView(ListView):
 
 
 def baselayer_view(request):
-    return HttpResponse(json.dumps({"defaultLayer": DefaultBaselayer.objects.first().layer.name,
+    return HttpResponse(json.dumps({"defaultLayer": BaselayerDefault.objects.first().layer.name,
                                     "layers":  map(lambda x: x.to_object(), Baselayer.objects.all())}))


### PR DESCRIPTION
Places the configurable basemaps in the window to make it easier for composer to read them. Also prevents an admin from having more than one global default basemap.

https://github.com/MapStory/mapstory/issues/1473