### PR TITLE
Issue 1900: SOCIALACCOUNT_AUTO_SIGNUP to True

### DIFF
--- a/mapstory/settings/base.py
+++ b/mapstory/settings/base.py
@@ -89,6 +89,7 @@ ENABLE_FORM_LOGIN = str_to_bool(os.environ.get('ENABLE_FORM_LOGIN', 'True'))
 USER_SNAP = str_to_bool(os.environ.get('USER_SNAP', 'False'))
 GOOGLE_ANALYTICS = os.environ.get('GOOGLE_ANALYTICS', '')
 SESSION_EXPIRE_AT_BROWSER_CLOSE = os.environ.get('SESSION_EXPIRE_AT_BROWSER_CLOSE', 'False')
+SOCIALACCOUNT_AUTO_SIGNUP = True
 
 #
 # Application Settings


### PR DESCRIPTION
Found this setting in geonode settings and it was set to False. I'm not sure of the timeline of when this was introduced into Storyscapes and why we were seeing the Signup form.